### PR TITLE
Add FastAPI web frontend for quiz mini app

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI web application package for the quiz bot."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from supabase_client import supabase
+
+logger = logging.getLogger(__name__)
+
+BASE_DIR = Path(__file__).resolve().parent
+
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+app = FastAPI(
+    title="Quiz WebApp",
+    description="Мини-приложение Telegram для викторины",
+    version="0.1.0",
+)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    """Главная страница с перечнем доступных викторин."""
+    load_error: str | None = None
+    try:
+        response = supabase.table("quizzes").select("id,title").order("title").execute()
+        quizzes: list[dict[str, Any]] = response.data or []
+    except Exception:  # pragma: no cover - network/runtime guard
+        logger.exception("Failed to load quizzes from Supabase")
+        quizzes = []
+        load_error = "Не удалось загрузить список викторин. Проверьте подключение к базе данных."
+    context = {
+        "request": request,
+        "quizzes": quizzes,
+        "load_error": load_error,
+    }
+    return templates.TemplateResponse("index.html", context)
+
+
+@app.get("/quiz/{quiz_id}", response_class=HTMLResponse)
+async def quiz_detail(quiz_id: int, request: Request) -> HTMLResponse:
+    """Возвращает содержимое викторины для HTMX-запросов."""
+    try:
+        quiz_response = supabase.table("quizzes").select("id,title").eq("id", quiz_id).limit(1).execute()
+        quiz = (quiz_response.data or [{}])[0] if quiz_response.data else None
+        if not quiz:
+            raise HTTPException(status_code=404, detail="Викторина не найдена")
+
+        questions_response = (
+            supabase.table("questions")
+            .select("id,text,explanation")
+            .eq("quiz_id", quiz_id)
+            .order("id")
+            .execute()
+        )
+        questions = questions_response.data or []
+        question_ids = [question["id"] for question in questions]
+
+        options_by_question: dict[int, list[dict[str, Any]]] = {}
+        if question_ids:
+            options_response = (
+                supabase.table("options")
+                .select("id,question_id,text,is_correct")
+                .in_("question_id", question_ids)
+                .order("id")
+                .execute()
+            )
+            for option in options_response.data or []:
+                options_by_question.setdefault(option["question_id"], []).append(option)
+
+        for question in questions:
+            question["options"] = options_by_question.get(question["id"], [])
+
+        context = {
+            "request": request,
+            "quiz": quiz,
+            "questions": questions,
+            "error": None,
+        }
+    except HTTPException:
+        raise
+    except Exception:  # pragma: no cover - network/runtime guard
+        logger.exception("Failed to load quiz from Supabase", extra={"quiz_id": quiz_id})
+        context = {
+            "request": request,
+            "quiz": None,
+            "questions": [],
+            "error": "Не удалось загрузить викторину. Попробуйте обновить страницу позже.",
+        }
+
+    return templates.TemplateResponse("partials/quiz_detail.html", context)
+
+
+@app.get("/health", response_class=HTMLResponse)
+async def healthcheck() -> HTMLResponse:
+    return HTMLResponse("ok")

--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ru" class="h-full">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#0f172a">
+    <title>{% block title %}Quiz WebApp{% endblock %}</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.12" integrity="sha384-xFADjDfsAbHn84qxdjQ671O5jM90oCbGyF/F7fs/3Gzdh0dX8GZFOD9oTi27Cw2x" crossorigin="anonymous"></script>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            if (window.Telegram?.WebApp) {
+                const webApp = window.Telegram.WebApp;
+                webApp.expand();
+                webApp.ready();
+            }
+        });
+    </script>
+    {% block head %}{% endblock %}
+</head>
+<body class="h-full bg-slate-900 text-slate-100">
+    <div class="min-h-full max-w-3xl mx-auto px-4 py-6">
+        <header class="mb-6">
+            <h1 class="text-2xl font-semibold text-white">{% block header %}Веб-викторина{% endblock %}</h1>
+            <p class="text-slate-400 text-sm mt-1">Мини-приложение Telegram для прохождения тестов</p>
+        </header>
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+</body>
+</html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}Викторины | Quiz WebApp{% endblock %}
+
+{% block content %}
+<section class="space-y-4">
+    <div class="bg-slate-800/60 border border-slate-700 rounded-xl p-4 shadow">
+        <h2 class="text-lg font-medium text-white">Доступные викторины</h2>
+        <p class="text-sm text-slate-400 mt-1">Выберите тест, чтобы просмотреть вопросы и начать прохождение.</p>
+    </div>
+
+    {% if load_error %}
+        <div class="border border-amber-500/40 bg-amber-900/40 text-amber-200 text-sm rounded-lg p-4">
+            {{ load_error }}
+        </div>
+    {% endif %}
+
+    <div class="grid gap-3" id="quiz-list">
+        {% if quizzes %}
+            {% for quiz in quizzes %}
+                <button
+                    class="w-full text-left bg-slate-800/60 border border-slate-700 hover:border-sky-500 transition rounded-lg p-4 flex items-center justify-between"
+                    hx-get="{{ url_for('quiz_detail', quiz_id=quiz.id) }}"
+                    hx-target="#quiz-detail"
+                    hx-swap="innerHTML"
+                >
+                    <span class="text-base font-medium text-white">{{ quiz.title }}</span>
+                    <svg class="w-5 h-5 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                    </svg>
+                </button>
+            {% endfor %}
+        {% else %}
+            <div class="text-sm text-slate-400 border border-dashed border-slate-700 rounded-lg p-4 text-center">
+                Викторины не найдены. Добавьте их через бота.
+            </div>
+        {% endif %}
+    </div>
+</section>
+
+<section class="mt-6" id="quiz-detail" hx-indicator="#quiz-loader">
+    <div class="border border-dashed border-slate-700 rounded-xl p-6 text-center text-slate-400">
+        Выберите викторину, чтобы увидеть вопросы.
+    </div>
+</section>
+
+<div id="quiz-loader" class="htmx-indicator hidden mt-4 text-center text-slate-400">
+    Загружаем вопросы…
+</div>
+{% endblock %}

--- a/webapp/templates/partials/quiz_detail.html
+++ b/webapp/templates/partials/quiz_detail.html
@@ -1,0 +1,44 @@
+{% if error %}
+    <div class="border border-amber-500/40 bg-amber-900/40 text-amber-100 rounded-xl p-5 text-sm">
+        {{ error }}
+    </div>
+{% elif not quiz %}
+    <div class="border border-rose-500/40 bg-rose-900/40 text-rose-100 rounded-xl p-5 text-sm">
+        Викторина не найдена.
+    </div>
+{% else %}
+    <div class="bg-slate-800/60 border border-slate-700 rounded-2xl shadow divide-y divide-slate-700/70">
+        <div class="p-5">
+            <h2 class="text-xl font-semibold text-white">{{ quiz.title }}</h2>
+            <p class="text-sm text-slate-400 mt-1">Всего вопросов: {{ questions|length }}</p>
+        </div>
+        <ol class="space-y-0">
+            {% for question in questions %}
+                <li class="p-5 space-y-4">
+                    <div>
+                        <p class="text-sm uppercase tracking-wide text-slate-500">Вопрос {{ loop.index }}</p>
+                        <p class="mt-1 text-base text-white">{{ question.text }}</p>
+                    </div>
+                    <div class="space-y-2">
+                        {% for option in question.options %}
+                            <div class="flex items-start gap-2 rounded-lg border border-slate-700/80 bg-slate-900/60 px-3 py-2">
+                                <span class="mt-1 h-2.5 w-2.5 rounded-full bg-slate-600"></span>
+                                <span class="text-sm text-slate-200">{{ option.text }}</span>
+                                {% if option.is_correct %}
+                                    <span class="ml-auto text-xs font-medium text-emerald-400">верный ответ</span>
+                                {% endif %}
+                            </div>
+                        {% endfor %}
+                    </div>
+                    {% if question.explanation %}
+                        <div class="rounded-lg border border-sky-500/40 bg-sky-950/40 px-3 py-2 text-sm text-sky-200">
+                            {{ question.explanation }}
+                        </div>
+                    {% endif %}
+                </li>
+            {% else %}
+                <li class="p-5 text-sm text-slate-400">Для этой викторины ещё не добавлены вопросы.</li>
+            {% endfor %}
+        </ol>
+    </div>
+{% endif %}


### PR DESCRIPTION
## Summary
- add a FastAPI webapp package with Jinja templates styled via Tailwind and htmx interactions
- fetch quizzes, questions, and options from Supabase to render interactive quiz details
- initialize the Telegram WebApp context for the mini app experience

## Testing
- python -m compileall webapp

------
https://chatgpt.com/codex/tasks/task_e_68dd015e72b4832d86c005569318ac0f