### PR TITLE
Add quiz type navigation with default classic categories

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -22,24 +22,203 @@ app = FastAPI(
     version="0.1.0",
 )
 
+DEFAULT_QUIZ_TYPE_SLUG = "classic"
+FALLBACK_QUIZ_TYPES: tuple[dict[str, Any], ...] = (
+    {
+        "id": "classic",
+        "slug": "classic",
+        "title": "Классическая викторина",
+        "description": "Вопросы с вариантами ответов и объяснениями.",
+    },
+    {
+        "id": "self_report",
+        "slug": "self_report",
+        "title": "Самооценочные тесты",
+        "description": "Тесты с развернутыми ответами и рекомендациями.",
+    },
+)
 
-@app.get("/", response_class=HTMLResponse)
-async def index(request: Request) -> HTMLResponse:
-    """Главная страница с перечнем доступных викторин."""
-    load_error: str | None = None
+
+def _normalize_quiz_type(raw_type: dict[str, Any]) -> dict[str, Any]:
+    slug = raw_type.get("slug") or raw_type.get("code") or raw_type.get("id")
+    if slug is None:
+        slug = DEFAULT_QUIZ_TYPE_SLUG
+    slug_str = str(slug)
+    title = (
+        raw_type.get("title")
+        or raw_type.get("name")
+        or raw_type.get("label")
+        or slug_str.capitalize()
+    )
+    description = raw_type.get("description") or raw_type.get("details")
+    return {
+        "id": raw_type.get("id"),
+        "slug": slug_str,
+        "title": title,
+        "description": description,
+    }
+
+
+def load_quiz_types() -> tuple[list[dict[str, Any]], str | None]:
     try:
-        response = supabase.table("quizzes").select("id,title").order("title").execute()
-        quizzes: list[dict[str, Any]] = response.data or []
+        base_query = (
+            supabase.table("quiz_types")
+            .select("id,slug,title,name,description,is_active,sort_order")
+            .eq("is_active", True)
+        )
+        try:
+            response = base_query.order("sort_order").order("id").execute()
+        except Exception:  # pragma: no cover - network/runtime guard
+            logger.debug(
+                "Retrying quiz types loading without sort_order column",
+                exc_info=True,
+            )
+            response = (
+                supabase.table("quiz_types")
+                .select("id,slug,title,name,description,is_active")
+                .eq("is_active", True)
+                .order("id")
+                .execute()
+            )
+        raw_types = response.data or []
+        if not raw_types:
+            return [dict(item) for item in FALLBACK_QUIZ_TYPES], None
+        return [_normalize_quiz_type(item) for item in raw_types], None
     except Exception:  # pragma: no cover - network/runtime guard
-        logger.exception("Failed to load quizzes from Supabase")
-        quizzes = []
-        load_error = "Не удалось загрузить список викторин. Проверьте подключение к базе данных."
+        logger.exception("Failed to load quiz types from Supabase")
+        return (
+            [dict(item) for item in FALLBACK_QUIZ_TYPES],
+            "Не удалось загрузить список видов викторин. Отображены доступные по умолчанию разделы.",
+        )
+
+
+def load_categories() -> tuple[list[dict[str, Any]], str | None]:
+    try:
+        response = (
+            supabase.table("categories")
+            .select("id,name")
+            .eq("is_active", True)
+            .order("name")
+            .execute()
+        )
+        categories = [
+            {"id": int(category["id"]), "name": category.get("name", "Без названия")}
+            for category in response.data or []
+            if category.get("id") is not None
+        ]
+        return categories, None
+    except Exception:  # pragma: no cover - network/runtime guard
+        logger.exception("Failed to load quiz categories from Supabase")
+        return (
+            [],
+            "Не удалось загрузить категории классической викторины. Попробуйте обновить страницу позже.",
+        )
+
+
+def load_quizzes(category_id: int) -> tuple[list[dict[str, Any]], str | None]:
+    try:
+        response = (
+            supabase.table("quizzes")
+            .select("id,title,is_active")
+            .eq("category_id", category_id)
+            .eq("is_active", True)
+            .order("title")
+            .execute()
+        )
+        quizzes = [
+            {"id": int(quiz["id"]), "title": quiz.get("title", "Без названия")}
+            for quiz in response.data or []
+            if quiz.get("id") is not None
+        ]
+        return quizzes, None
+    except Exception:  # pragma: no cover - network/runtime guard
+        logger.exception(
+            "Failed to load quizzes for category from Supabase",
+            extra={"category_id": category_id},
+        )
+        return (
+            [],
+            "Не удалось загрузить викторины выбранной категории. Попробуйте обновить страницу позже.",
+        )
+
+
+def build_quiz_type_context(
+    request: Request, quiz_type_slug: str | None, category_id: int | None
+) -> dict[str, Any]:
+    quiz_types, types_error = load_quiz_types()
+    active_type = next(
+        (quiz_type for quiz_type in quiz_types if quiz_type["slug"] == quiz_type_slug),
+        None,
+    )
+    if active_type is None and quiz_types:
+        active_type = next(
+            (
+                quiz_type
+                for quiz_type in quiz_types
+                if quiz_type["slug"] == DEFAULT_QUIZ_TYPE_SLUG
+            ),
+            quiz_types[0],
+        )
+    elif active_type is None:
+        active_type = dict(FALLBACK_QUIZ_TYPES[0])
+
+    categories: list[dict[str, Any]] = []
+    categories_error: str | None = None
+    category_notice: str | None = None
+    quizzes: list[dict[str, Any]] = []
+    quizzes_error: str | None = None
+    selected_category: dict[str, Any] | None = None
+
+    if active_type["slug"] == "classic":
+        categories, categories_error = load_categories()
+        if categories and category_id is not None:
+            selected_category = next(
+                (category for category in categories if category["id"] == category_id),
+                None,
+            )
+            if selected_category is None:
+                category_notice = "Выбранная категория не найдена или недоступна."
+                category_id = None
+        if selected_category is not None:
+            quizzes, quizzes_error = load_quizzes(selected_category["id"])
+    else:
+        category_id = None
+
     context = {
         "request": request,
+        "quiz_types": quiz_types,
+        "active_type": active_type,
+        "types_error": types_error,
+        "categories": categories,
+        "categories_error": categories_error,
+        "category_notice": category_notice,
+        "selected_category": selected_category,
         "quizzes": quizzes,
-        "load_error": load_error,
+        "quizzes_error": quizzes_error,
     }
+    return context
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(
+    request: Request,
+    quiz_type: str | None = None,
+    category_id: int | None = None,
+) -> HTMLResponse:
+    """Главная страница с выбором вида викторины и доступных категорий."""
+    context = build_quiz_type_context(request, quiz_type, category_id)
     return templates.TemplateResponse("index.html", context)
+
+
+@app.get("/quiz-type/{quiz_type_slug}", response_class=HTMLResponse)
+async def load_quiz_type(
+    quiz_type_slug: str,
+    request: Request,
+    category_id: int | None = None,
+) -> HTMLResponse:
+    """Возвращает панель с категориями и викторинами для выбранного вида."""
+    context = build_quiz_type_context(request, quiz_type_slug, category_id)
+    return templates.TemplateResponse("partials/quiz_type_panel.html", context)
 
 
 @app.get("/quiz/{quiz_id}", response_class=HTMLResponse)

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -3,48 +3,7 @@
 {% block title %}Викторины | Quiz WebApp{% endblock %}
 
 {% block content %}
-<section class="space-y-4">
-    <div class="bg-slate-800/60 border border-slate-700 rounded-xl p-4 shadow">
-        <h2 class="text-lg font-medium text-white">Доступные викторины</h2>
-        <p class="text-sm text-slate-400 mt-1">Выберите тест, чтобы просмотреть вопросы и начать прохождение.</p>
-    </div>
-
-    {% if load_error %}
-        <div class="border border-amber-500/40 bg-amber-900/40 text-amber-200 text-sm rounded-lg p-4">
-            {{ load_error }}
-        </div>
-    {% endif %}
-
-    <div class="grid gap-3" id="quiz-list">
-        {% if quizzes %}
-            {% for quiz in quizzes %}
-                <button
-                    class="w-full text-left bg-slate-800/60 border border-slate-700 hover:border-sky-500 transition rounded-lg p-4 flex items-center justify-between"
-                    hx-get="{{ url_for('quiz_detail', quiz_id=quiz.id) }}"
-                    hx-target="#quiz-detail"
-                    hx-swap="innerHTML"
-                >
-                    <span class="text-base font-medium text-white">{{ quiz.title }}</span>
-                    <svg class="w-5 h-5 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-                    </svg>
-                </button>
-            {% endfor %}
-        {% else %}
-            <div class="text-sm text-slate-400 border border-dashed border-slate-700 rounded-lg p-4 text-center">
-                Викторины не найдены. Добавьте их через бота.
-            </div>
-        {% endif %}
-    </div>
-</section>
-
-<section class="mt-6" id="quiz-detail" hx-indicator="#quiz-loader">
-    <div class="border border-dashed border-slate-700 rounded-xl p-6 text-center text-slate-400">
-        Выберите викторину, чтобы увидеть вопросы.
-    </div>
-</section>
-
-<div id="quiz-loader" class="htmx-indicator hidden mt-4 text-center text-slate-400">
-    Загружаем вопросы…
+<div id="quiz-type-container" hx-target="this" hx-swap="outerHTML">
+    {% include "partials/quiz_type_panel.html" %}
 </div>
 {% endblock %}

--- a/webapp/templates/partials/quiz_type_panel.html
+++ b/webapp/templates/partials/quiz_type_panel.html
@@ -1,0 +1,143 @@
+<div id="quiz-type-container" class="space-y-6">
+    <section class="space-y-4">
+        <div class="bg-slate-800/60 border border-slate-700 rounded-xl p-5 shadow">
+            <div class="flex flex-col gap-2">
+                <h2 class="text-lg font-semibold text-white">Виды викторин</h2>
+                <p class="text-sm text-slate-400">
+                    Выберите формат, чтобы посмотреть доступные категории и начать прохождение тестов.
+                </p>
+                <p class="text-xs text-slate-500">
+                    Активный раздел: <span class="text-slate-200">{{ active_type.title }}</span>
+                    {% if active_type.description %}
+                        — {{ active_type.description }}
+                    {% endif %}
+                </p>
+            </div>
+            {% if types_error %}
+                <div class="mt-4 border border-amber-500/40 bg-amber-900/40 text-amber-200 text-sm rounded-lg p-3">
+                    {{ types_error }}
+                </div>
+            {% endif %}
+            <div class="flex flex-wrap gap-2 mt-4">
+                {% for quiz_type in quiz_types %}
+                    {% set is_active = quiz_type.slug == active_type.slug %}
+                    <button
+                        type="button"
+                        class="px-4 py-2 rounded-lg text-sm font-medium border transition focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-sky-500 {{ 'bg-sky-500/90 border-sky-400 text-white shadow' if is_active else 'bg-slate-800/60 border-slate-600 text-slate-200 hover:border-sky-500' }}"
+                        hx-get="{{ url_for('load_quiz_type', quiz_type_slug=quiz_type.slug) }}"
+                        hx-target="#quiz-type-container"
+                        hx-swap="outerHTML"
+                        hx-indicator="#quiz-loader"
+                        aria-pressed="{{ 'true' if is_active else 'false' }}"
+                    >
+                        {{ quiz_type.title }}
+                    </button>
+                {% endfor %}
+            </div>
+        </div>
+
+        {% if active_type.slug == 'classic' %}
+            <div class="space-y-4">
+                <div>
+                    <h3 class="text-base font-semibold text-white">Категории классической викторины</h3>
+                    <p class="text-sm text-slate-400 mt-1">Выберите категорию, чтобы увидеть список викторин.</p>
+                </div>
+                {% if categories_error %}
+                    <div class="border border-amber-500/40 bg-amber-900/40 text-amber-200 text-sm rounded-lg p-4">
+                        {{ categories_error }}
+                    </div>
+                {% endif %}
+                {% if category_notice %}
+                    <div class="border border-amber-500/40 bg-amber-900/40 text-amber-200 text-sm rounded-lg p-4">
+                        {{ category_notice }}
+                    </div>
+                {% endif %}
+
+                {% if categories %}
+                    <div class="grid gap-3" id="category-list">
+                        {% for category in categories %}
+                            {% set is_selected = selected_category and selected_category.id == category.id %}
+                            <button
+                                type="button"
+                                class="w-full text-left rounded-lg border transition p-4 flex items-center justify-between {{ 'border-sky-400 bg-sky-500/20 text-white shadow' if is_selected else 'border-slate-700 bg-slate-800/60 hover:border-sky-500 text-slate-200' }}"
+                                hx-get="{{ url_for('load_quiz_type', quiz_type_slug=active_type.slug) }}?category_id={{ category.id }}"
+                                hx-target="#quiz-type-container"
+                                hx-swap="outerHTML"
+                                hx-indicator="#quiz-loader"
+                                aria-pressed="{{ 'true' if is_selected else 'false' }}"
+                            >
+                                <span class="text-base font-medium">{{ category.name }}</span>
+                                <svg class="w-5 h-5 {{ 'text-sky-200' if is_selected else 'text-slate-400' }}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                                </svg>
+                            </button>
+                        {% endfor %}
+                    </div>
+                {% elif not categories_error %}
+                    <div class="text-sm text-slate-400 border border-dashed border-slate-700 rounded-lg p-4 text-center">
+                        Категории не найдены. Добавьте их через админ-панель или бота.
+                    </div>
+                {% endif %}
+            </div>
+
+            <section class="mt-6" id="quiz-list">
+                {% if selected_category %}
+                    <div class="mb-4">
+                        <h3 class="text-base font-semibold text-white">Викторины категории «{{ selected_category.name }}»</h3>
+                        <p class="text-sm text-slate-400 mt-1">Выберите викторину, чтобы просмотреть вопросы.</p>
+                    </div>
+                    {% if quizzes_error %}
+                        <div class="border border-amber-500/40 bg-amber-900/40 text-amber-200 text-sm rounded-lg p-4">
+                            {{ quizzes_error }}
+                        </div>
+                    {% elif quizzes %}
+                        <div class="grid gap-3">
+                            {% for quiz in quizzes %}
+                                <button
+                                    class="w-full text-left bg-slate-800/60 border border-slate-700 hover:border-sky-500 transition rounded-lg p-4 flex items-center justify-between"
+                                    hx-get="{{ url_for('quiz_detail', quiz_id=quiz.id) }}"
+                                    hx-target="#quiz-detail"
+                                    hx-swap="innerHTML"
+                                    hx-indicator="#quiz-loader"
+                                >
+                                    <span class="text-base font-medium text-white">{{ quiz.title }}</span>
+                                    <svg class="w-5 h-5 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                                    </svg>
+                                </button>
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <div class="text-sm text-slate-400 border border-dashed border-slate-700 rounded-lg p-4 text-center">
+                            В этой категории пока нет активных викторин.
+                        </div>
+                    {% endif %}
+                {% else %}
+                    <div class="border border-dashed border-slate-700 rounded-xl p-6 text-center text-slate-400">
+                        Выберите категорию, чтобы увидеть список викторин.
+                    </div>
+                {% endif %}
+            </section>
+        {% else %}
+            <section class="border border-slate-700 rounded-xl p-6 bg-slate-800/40 text-slate-200">
+                <h3 class="text-base font-semibold text-white">{{ active_type.title }}</h3>
+                <p class="text-sm text-slate-400 mt-2">
+                    {{ active_type.description or 'Раздел будет доступен позже. Пока можно пройти классические викторины.' }}
+                </p>
+            </section>
+            <section class="mt-6 border border-dashed border-slate-700 rounded-xl p-6 text-center text-slate-400" id="quiz-list">
+                Выберите «Классическая викторина», чтобы просмотреть категории и тесты.
+            </section>
+        {% endif %}
+    </section>
+
+    <section class="mt-6" id="quiz-detail" hx-indicator="#quiz-loader">
+        <div class="border border-dashed border-slate-700 rounded-xl p-6 text-center text-slate-400">
+            Выберите викторину, чтобы увидеть вопросы.
+        </div>
+    </section>
+
+    <div id="quiz-loader" class="htmx-indicator hidden mt-4 text-center text-slate-400">
+        Загружаем данные…
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- load quiz types, categories, and quizzes from Supabase with graceful fallbacks and shared context helpers
- default the landing page to the classic quiz type while exposing an HTMX selector for switching quiz formats
- render categories and quizzes through a reusable partial so the classic section is visible on initial load

## Testing
- python -m compileall webapp

------
https://chatgpt.com/codex/tasks/task_e_68dd087d12c0832da7ae8955b75238ec