### PR TITLE
Add FastAPI HTMX quiz preview example

### DIFF
--- a/examples/htmx_preview/main.py
+++ b/examples/htmx_preview/main.py
@@ -1,0 +1,210 @@
+"""Мини-пример FastAPI + HTMX для викторин."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+BASE_DIR = Path(__file__).resolve().parent
+TEMPLATES_DIR = BASE_DIR / "templates"
+
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+app = FastAPI(title="HTMX Quiz Preview", version="0.1.0")
+
+CATEGORIES: list[dict[str, Any]] = [
+    {
+        "id": 1,
+        "name": "История",
+        "description": "Проверьте знания ключевых событий и дат.",
+    },
+    {
+        "id": 2,
+        "name": "Наука",
+        "description": "От физики до биологии — широкий кругозор.",
+    },
+    {
+        "id": 3,
+        "name": "Спорт",
+        "description": "Самые памятные матчи и рекорды.",
+    },
+]
+
+QUIZZES_BY_CATEGORY: dict[int, list[dict[str, Any]]] = {
+    1: [
+        {"id": 101, "title": "Мировая история"},
+        {"id": 102, "title": "История России"},
+    ],
+    2: [
+        {"id": 201, "title": "Великие ученые"},
+        {"id": 202, "title": "Открытия XX века"},
+    ],
+    3: [
+        {"id": 301, "title": "Олимпийские игры"},
+        {"id": 302, "title": "Футбол"},
+    ],
+}
+
+QUIZ_DETAILS: dict[int, dict[str, Any]] = {
+    101: {
+        "title": "Мировая история",
+        "category_id": 1,
+        "questions": [
+            {
+                "text": "Какая цивилизация построила пирамиду Хеопса?",
+                "options": ["Древний Египет", "Майя", "Инки", "Римляне"],
+                "answer": "Древний Египет",
+            },
+            {
+                "text": "Когда началась Первая мировая война?",
+                "options": ["1812", "1914", "1939", "1945"],
+                "answer": "1914",
+            },
+        ],
+    },
+    102: {
+        "title": "История России",
+        "category_id": 1,
+        "questions": [
+            {
+                "text": "В каком году была крещение Руси?",
+                "options": ["862", "988", "1240", "1380"],
+                "answer": "988",
+            },
+            {
+                "text": "Кто правил страной в период Петровских реформ?",
+                "options": ["Иван Грозный", "Петр I", "Екатерина II", "Александр I"],
+                "answer": "Петр I",
+            },
+        ],
+    },
+    201: {
+        "title": "Великие ученые",
+        "category_id": 2,
+        "questions": [
+            {
+                "text": "Кто открыл закон всемирного тяготения?",
+                "options": ["Галилей", "Ньютон", "Коперник", "Эйнштейн"],
+                "answer": "Ньютон",
+            },
+            {
+                "text": "Кто разработал теорию относительности?",
+                "options": ["Эйнштейн", "Фейнман", "Максвелл", "Боров"],
+                "answer": "Эйнштейн",
+            },
+        ],
+    },
+    202: {
+        "title": "Открытия XX века",
+        "category_id": 2,
+        "questions": [
+            {
+                "text": "В каком году впервые запустили искусственный спутник Земли?",
+                "options": ["1945", "1957", "1961", "1969"],
+                "answer": "1957",
+            },
+            {
+                "text": "Кто открыл структуру ДНК?",
+                "options": [
+                    "Розалинд Франклин",
+                    "Уотсон и Крик",
+                    "Дарвин",
+                    "Менделеев",
+                ],
+                "answer": "Уотсон и Крик",
+            },
+        ],
+    },
+    301: {
+        "title": "Олимпийские игры",
+        "category_id": 3,
+        "questions": [
+            {
+                "text": "Где прошли первые современные Олимпийские игры?",
+                "options": ["Афины", "Париж", "Лондон", "Берлин"],
+                "answer": "Афины",
+            },
+            {
+                "text": "Как часто проводятся летние Олимпийские игры?",
+                "options": ["Каждый год", "Раз в два года", "Раз в четыре года", "Раз в пять лет"],
+                "answer": "Раз в четыре года",
+            },
+        ],
+    },
+    302: {
+        "title": "Футбол",
+        "category_id": 3,
+        "questions": [
+            {
+                "text": "Сколько игроков в команде на поле в официальном матче?",
+                "options": ["7", "9", "11", "13"],
+                "answer": "11",
+            },
+            {
+                "text": "Какая страна выиграла ЧМ-2018?",
+                "options": ["Германия", "Аргентина", "Франция", "Бразилия"],
+                "answer": "Франция",
+            },
+        ],
+    },
+}
+
+
+@app.get("/", response_class=HTMLResponse)
+async def read_categories(request: Request) -> HTMLResponse:
+    context = {
+        "request": request,
+        "categories": CATEGORIES,
+        "active_view": "categories",
+    }
+    return templates.TemplateResponse("index.html", context)
+
+
+def _is_hx(request: Request) -> bool:
+    return request.headers.get("Hx-Request", "false").lower() == "true"
+
+
+@app.get("/category/{category_id}", response_class=HTMLResponse)
+async def read_category(category_id: int, request: Request) -> HTMLResponse:
+    category = next((item for item in CATEGORIES if item["id"] == category_id), None)
+    if category is None:
+        raise HTTPException(status_code=404, detail="Категория не найдена")
+
+    quizzes = QUIZZES_BY_CATEGORY.get(category_id, [])
+    context = {
+        "request": request,
+        "categories": CATEGORIES,
+        "active_view": "category",
+        "current_category": category,
+        "quizzes": quizzes,
+    }
+    if _is_hx(request):
+        return templates.TemplateResponse("category.html", context)
+    return templates.TemplateResponse("index.html", context)
+
+
+@app.get("/quiz/{quiz_id}", response_class=HTMLResponse)
+async def read_quiz(quiz_id: int, request: Request) -> HTMLResponse:
+    quiz = QUIZ_DETAILS.get(quiz_id)
+    if quiz is None:
+        raise HTTPException(status_code=404, detail="Викторина не найдена")
+
+    category = next(
+        (item for item in CATEGORIES if item["id"] == quiz["category_id"]),
+        None,
+    )
+    if category is None:
+        raise HTTPException(status_code=404, detail="Категория викторины не найдена")
+    context = {
+        "request": request,
+        "categories": CATEGORIES,
+        "active_view": "quiz",
+        "current_category": category,
+        "quiz": quiz,
+    }
+    if _is_hx(request):
+        return templates.TemplateResponse("quiz.html", context)
+    return templates.TemplateResponse("index.html", context)

--- a/examples/htmx_preview/main.py
+++ b/examples/htmx_preview/main.py
@@ -1,185 +1,263 @@
-"""Мини-пример FastAPI + HTMX для викторин."""
+"""Мини-пример FastAPI + HTMX для викторин с реальными данными из Supabase."""
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
+from starlette.concurrency import run_in_threadpool
+
+from supabase_client import supabase
 
 BASE_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = BASE_DIR / "templates"
 
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
-app = FastAPI(title="HTMX Quiz Preview", version="0.1.0")
+app = FastAPI(title="HTMX Quiz Preview", version="0.2.0")
 
-CATEGORIES: list[dict[str, Any]] = [
-    {
-        "id": 1,
-        "name": "История",
-        "description": "Проверьте знания ключевых событий и дат.",
-    },
-    {
-        "id": 2,
-        "name": "Наука",
-        "description": "От физики до биологии — широкий кругозор.",
-    },
-    {
-        "id": 3,
-        "name": "Спорт",
-        "description": "Самые памятные матчи и рекорды.",
-    },
-]
-
-QUIZZES_BY_CATEGORY: dict[int, list[dict[str, Any]]] = {
-    1: [
-        {"id": 101, "title": "Мировая история"},
-        {"id": 102, "title": "История России"},
-    ],
-    2: [
-        {"id": 201, "title": "Великие ученые"},
-        {"id": 202, "title": "Открытия XX века"},
-    ],
-    3: [
-        {"id": 301, "title": "Олимпийские игры"},
-        {"id": 302, "title": "Футбол"},
-    ],
-}
-
-QUIZ_DETAILS: dict[int, dict[str, Any]] = {
-    101: {
-        "title": "Мировая история",
-        "category_id": 1,
-        "questions": [
-            {
-                "text": "Какая цивилизация построила пирамиду Хеопса?",
-                "options": ["Древний Египет", "Майя", "Инки", "Римляне"],
-                "answer": "Древний Египет",
-            },
-            {
-                "text": "Когда началась Первая мировая война?",
-                "options": ["1812", "1914", "1939", "1945"],
-                "answer": "1914",
-            },
-        ],
-    },
-    102: {
-        "title": "История России",
-        "category_id": 1,
-        "questions": [
-            {
-                "text": "В каком году была крещение Руси?",
-                "options": ["862", "988", "1240", "1380"],
-                "answer": "988",
-            },
-            {
-                "text": "Кто правил страной в период Петровских реформ?",
-                "options": ["Иван Грозный", "Петр I", "Екатерина II", "Александр I"],
-                "answer": "Петр I",
-            },
-        ],
-    },
-    201: {
-        "title": "Великие ученые",
-        "category_id": 2,
-        "questions": [
-            {
-                "text": "Кто открыл закон всемирного тяготения?",
-                "options": ["Галилей", "Ньютон", "Коперник", "Эйнштейн"],
-                "answer": "Ньютон",
-            },
-            {
-                "text": "Кто разработал теорию относительности?",
-                "options": ["Эйнштейн", "Фейнман", "Максвелл", "Боров"],
-                "answer": "Эйнштейн",
-            },
-        ],
-    },
-    202: {
-        "title": "Открытия XX века",
-        "category_id": 2,
-        "questions": [
-            {
-                "text": "В каком году впервые запустили искусственный спутник Земли?",
-                "options": ["1945", "1957", "1961", "1969"],
-                "answer": "1957",
-            },
-            {
-                "text": "Кто открыл структуру ДНК?",
-                "options": [
-                    "Розалинд Франклин",
-                    "Уотсон и Крик",
-                    "Дарвин",
-                    "Менделеев",
-                ],
-                "answer": "Уотсон и Крик",
-            },
-        ],
-    },
-    301: {
-        "title": "Олимпийские игры",
-        "category_id": 3,
-        "questions": [
-            {
-                "text": "Где прошли первые современные Олимпийские игры?",
-                "options": ["Афины", "Париж", "Лондон", "Берлин"],
-                "answer": "Афины",
-            },
-            {
-                "text": "Как часто проводятся летние Олимпийские игры?",
-                "options": ["Каждый год", "Раз в два года", "Раз в четыре года", "Раз в пять лет"],
-                "answer": "Раз в четыре года",
-            },
-        ],
-    },
-    302: {
-        "title": "Футбол",
-        "category_id": 3,
-        "questions": [
-            {
-                "text": "Сколько игроков в команде на поле в официальном матче?",
-                "options": ["7", "9", "11", "13"],
-                "answer": "11",
-            },
-            {
-                "text": "Какая страна выиграла ЧМ-2018?",
-                "options": ["Германия", "Аргентина", "Франция", "Бразилия"],
-                "answer": "Франция",
-            },
-        ],
-    },
-}
+logger = logging.getLogger(__name__)
 
 
-@app.get("/", response_class=HTMLResponse)
-async def read_categories(request: Request) -> HTMLResponse:
-    context = {
-        "request": request,
-        "categories": CATEGORIES,
-        "active_view": "categories",
-    }
-    return templates.TemplateResponse("index.html", context)
+def _to_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def get_categories() -> tuple[list[dict[str, Any]], str | None]:
+    """Загружает активные категории викторин."""
+
+    def _load() -> list[dict[str, Any]]:
+        response = (
+            supabase.table("categories")
+            .select("id,name,description,is_active")
+            .eq("is_active", True)
+            .order("name")
+            .execute()
+        )
+        categories: list[dict[str, Any]] = []
+        for raw in response.data or []:
+            category_id = _to_int(raw.get("id"))
+            if category_id is None:
+                continue
+            categories.append(
+                {
+                    "id": category_id,
+                    "name": raw.get("name") or f"Категория №{category_id}",
+                    "description": raw.get("description")
+                    or "Описание категории появится позже.",
+                }
+            )
+        return categories
+
+    try:
+        categories = await run_in_threadpool(_load)
+        return categories, None
+    except Exception:  # pragma: no cover - защита от сетевых ошибок
+        logger.exception("Failed to load categories from Supabase")
+        return (
+            [],
+            "Не удалось загрузить категории викторин. Попробуйте обновить страницу позже.",
+        )
+
+
+async def get_category_by_id(category_id: int) -> dict[str, Any] | None:
+    """Возвращает одну категорию по идентификатору."""
+
+    def _load() -> dict[str, Any] | None:
+        response = (
+            supabase.table("categories")
+            .select("id,name,description")
+            .eq("id", category_id)
+            .limit(1)
+            .execute()
+        )
+        if not response.data:
+            return None
+        raw = response.data[0]
+        return {
+            "id": category_id,
+            "name": raw.get("name") or f"Категория №{category_id}",
+            "description": raw.get("description")
+            or "Описание категории появится позже.",
+        }
+
+    try:
+        return await run_in_threadpool(_load)
+    except Exception:  # pragma: no cover - защита от сетевых ошибок
+        logger.exception(
+            "Failed to load category from Supabase", extra={"category_id": category_id}
+        )
+        return None
+
+
+async def get_quizzes(category_id: int) -> tuple[list[dict[str, Any]], str | None]:
+    """Загружает список активных викторин категории."""
+
+    def _load() -> list[dict[str, Any]]:
+        response = (
+            supabase.table("quizzes")
+            .select("id,title,category_id,is_active")
+            .eq("category_id", category_id)
+            .eq("is_active", True)
+            .order("title")
+            .execute()
+        )
+        quizzes: list[dict[str, Any]] = []
+        for raw in response.data or []:
+            quiz_id = _to_int(raw.get("id"))
+            if quiz_id is None:
+                continue
+            quizzes.append(
+                {
+                    "id": quiz_id,
+                    "title": raw.get("title") or f"Викторина №{quiz_id}",
+                    "category_id": category_id,
+                }
+            )
+        return quizzes
+
+    try:
+        quizzes = await run_in_threadpool(_load)
+        return quizzes, None
+    except Exception:  # pragma: no cover - защита от сетевых ошибок
+        logger.exception(
+            "Failed to load quizzes for category", extra={"category_id": category_id}
+        )
+        return (
+            [],
+            "Не удалось загрузить викторины выбранной категории. Попробуйте обновить страницу позже.",
+        )
+
+
+async def get_quiz_detail(quiz_id: int) -> tuple[dict[str, Any] | None, str | None]:
+    """Возвращает подробности викторины и связанные вопросы."""
+
+    class _QuizNotFound(Exception):
+        pass
+
+    def _load() -> dict[str, Any]:
+        quiz_response = (
+            supabase.table("quizzes")
+            .select("id,title,category_id,description")
+            .eq("id", quiz_id)
+            .limit(1)
+            .execute()
+        )
+        if not quiz_response.data:
+            raise _QuizNotFound
+        quiz_raw = quiz_response.data[0]
+        category_id = _to_int(quiz_raw.get("category_id"))
+
+        questions_response = (
+            supabase.table("questions")
+            .select("id,text,explanation")
+            .eq("quiz_id", quiz_id)
+            .order("id")
+            .execute()
+        )
+        questions: list[dict[str, Any]] = []
+        question_ids: list[int] = []
+        for raw_question in questions_response.data or []:
+            question_id = _to_int(raw_question.get("id"))
+            if question_id is None:
+                continue
+            question_ids.append(question_id)
+            questions.append(
+                {
+                    "id": question_id,
+                    "text": raw_question.get("text") or "Вопрос без текста",
+                    "explanation": raw_question.get("explanation"),
+                    "options": [],
+                    "correct_answer": None,
+                }
+            )
+
+        options_by_question: dict[int, list[dict[str, Any]]] = {qid: [] for qid in question_ids}
+        if question_ids:
+            options_response = (
+                supabase.table("options")
+                .select("id,question_id,text,is_correct")
+                .in_("question_id", question_ids)
+                .order("id")
+                .execute()
+            )
+            for raw_option in options_response.data or []:
+                question_id = _to_int(raw_option.get("question_id"))
+                option_text = raw_option.get("text")
+                if question_id is None or option_text is None:
+                    continue
+                option_payload = {
+                    "text": option_text,
+                    "is_correct": bool(raw_option.get("is_correct")),
+                }
+                options_by_question.setdefault(question_id, []).append(option_payload)
+
+        for question in questions:
+            options = options_by_question.get(question["id"], [])
+            question["options"] = options
+            question["correct_answer"] = next(
+                (option["text"] for option in options if option["is_correct"]),
+                None,
+            )
+
+        return {
+            "id": quiz_id,
+            "title": quiz_raw.get("title") or f"Викторина №{quiz_id}",
+            "description": quiz_raw.get("description"),
+            "category_id": category_id,
+            "questions": questions,
+        }
+
+    try:
+        quiz = await run_in_threadpool(_load)
+        return quiz, None
+    except _QuizNotFound:
+        return None, None
+    except Exception:  # pragma: no cover - защита от сетевых ошибок
+        logger.exception("Failed to load quiz from Supabase", extra={"quiz_id": quiz_id})
+        return None, "Не удалось загрузить викторину. Попробуйте обновить страницу позже."
 
 
 def _is_hx(request: Request) -> bool:
     return request.headers.get("Hx-Request", "false").lower() == "true"
 
 
+@app.get("/", response_class=HTMLResponse)
+async def read_categories(request: Request) -> HTMLResponse:
+    categories, categories_error = await get_categories()
+    context = {
+        "request": request,
+        "categories": categories,
+        "categories_error": categories_error,
+        "active_view": "categories",
+    }
+    return templates.TemplateResponse("index.html", context)
+
+
 @app.get("/category/{category_id}", response_class=HTMLResponse)
 async def read_category(category_id: int, request: Request) -> HTMLResponse:
-    category = next((item for item in CATEGORIES if item["id"] == category_id), None)
+    categories, categories_error = await get_categories()
+    category = next((item for item in categories if item["id"] == category_id), None)
+    if category is None:
+        category = await get_category_by_id(category_id)
     if category is None:
         raise HTTPException(status_code=404, detail="Категория не найдена")
 
-    quizzes = QUIZZES_BY_CATEGORY.get(category_id, [])
+    quizzes, quizzes_error = await get_quizzes(category["id"])
     context = {
         "request": request,
-        "categories": CATEGORIES,
+        "categories": categories,
+        "categories_error": categories_error,
         "active_view": "category",
         "current_category": category,
         "quizzes": quizzes,
+        "quizzes_error": quizzes_error,
     }
     if _is_hx(request):
         return templates.TemplateResponse("category.html", context)
@@ -188,22 +266,26 @@ async def read_category(category_id: int, request: Request) -> HTMLResponse:
 
 @app.get("/quiz/{quiz_id}", response_class=HTMLResponse)
 async def read_quiz(quiz_id: int, request: Request) -> HTMLResponse:
-    quiz = QUIZ_DETAILS.get(quiz_id)
-    if quiz is None:
+    quiz, quiz_error = await get_quiz_detail(quiz_id)
+    if quiz is None and quiz_error is None:
         raise HTTPException(status_code=404, detail="Викторина не найдена")
 
-    category = next(
-        (item for item in CATEGORIES if item["id"] == quiz["category_id"]),
-        None,
-    )
-    if category is None:
-        raise HTTPException(status_code=404, detail="Категория викторины не найдена")
+    current_category = None
+    if quiz and quiz.get("category_id") is not None:
+        current_category = await get_category_by_id(quiz["category_id"])
+        if current_category is None:
+            current_category = {
+                "id": quiz["category_id"],
+                "name": f"Категория №{quiz['category_id']}",
+                "description": None,
+            }
+
     context = {
         "request": request,
-        "categories": CATEGORIES,
         "active_view": "quiz",
-        "current_category": category,
+        "current_category": current_category,
         "quiz": quiz,
+        "quiz_error": quiz_error,
     }
     if _is_hx(request):
         return templates.TemplateResponse("quiz.html", context)

--- a/examples/htmx_preview/templates/category.html
+++ b/examples/htmx_preview/templates/category.html
@@ -1,0 +1,32 @@
+<button
+  class="back-button"
+  hx-get="/"
+  hx-target="#content"
+  hx-push-url="true"
+  hx-indicator=".htmx-indicator"
+>
+  ← Назад к категориям
+</button>
+<header>
+  <h1>{{ current_category.name }}</h1>
+  <p class="subtitle">Выберите викторину в выбранной категории.</p>
+</header>
+<section class="grid">
+  {% if quizzes %}
+    {% for quiz in quizzes %}
+      <article
+        class="card"
+        hx-get="/quiz/{{ quiz.id }}"
+        hx-target="#content"
+        hx-push-url="true"
+        hx-indicator=".htmx-indicator"
+      >
+        <span class="badge">Викторина</span>
+        <div class="card-title">{{ quiz.title }}</div>
+        <div class="card-description">Откройте, чтобы посмотреть список вопросов.</div>
+      </article>
+    {% endfor %}
+  {% else %}
+    <p>В этой категории пока нет активных викторин.</p>
+  {% endif %}
+</section>

--- a/examples/htmx_preview/templates/category.html
+++ b/examples/htmx_preview/templates/category.html
@@ -9,10 +9,15 @@
 </button>
 <header>
   <h1>{{ current_category.name }}</h1>
-  <p class="subtitle">Выберите викторину в выбранной категории.</p>
+  <p class="subtitle">
+    {{ current_category.description or "Выберите викторину в выбранной категории." }}
+  </p>
 </header>
-<section class="grid">
-  {% if quizzes %}
+{% if quizzes_error %}
+  <p class="notice">{{ quizzes_error }}</p>
+{% endif %}
+{% if quizzes %}
+  <section class="grid">
     {% for quiz in quizzes %}
       <article
         class="card"
@@ -26,7 +31,7 @@
         <div class="card-description">Откройте, чтобы посмотреть список вопросов.</div>
       </article>
     {% endfor %}
-  {% else %}
-    <p>В этой категории пока нет активных викторин.</p>
-  {% endif %}
-</section>
+  </section>
+{% elif not quizzes_error %}
+  <p class="empty-state">В этой категории пока нет активных викторин.</p>
+{% endif %}

--- a/examples/htmx_preview/templates/index.html
+++ b/examples/htmx_preview/templates/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Викторины — HTMX пример</title>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f3f4f6;
+        --bg-dark: #111827;
+        --card-bg: #ffffff;
+        --card-bg-dark: #1f2937;
+        --text: #111827;
+        --text-muted: #6b7280;
+        --accent: #6366f1;
+        --shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+        background: linear-gradient(135deg, rgba(99, 102, 241, 0.06), rgba(59, 130, 246, 0.04));
+        background-color: var(--bg);
+        color: var(--text);
+        min-height: 100vh;
+        display: flex;
+        align-items: stretch;
+        justify-content: center;
+        padding: 3rem 1rem;
+      }
+
+      .app-shell {
+        width: min(960px, 100%);
+        background: var(--card-bg);
+        border-radius: 24px;
+        padding: 2.5rem;
+        box-shadow: var(--shadow);
+        position: relative;
+        overflow: hidden;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: var(--bg-dark);
+          color: #e5e7eb;
+        }
+
+        .app-shell {
+          background: var(--card-bg-dark);
+          box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+        }
+      }
+
+      h1 {
+        font-size: clamp(2rem, 1.6rem + 1vw, 2.8rem);
+        margin: 0 0 0.75rem;
+      }
+
+      p.subtitle {
+        margin-top: 0;
+        margin-bottom: 2.5rem;
+        color: var(--text-muted);
+        font-size: 1.05rem;
+      }
+
+      .grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .card {
+        background: rgba(255, 255, 255, 0.85);
+        border-radius: 18px;
+        padding: 1.75rem;
+        text-decoration: none;
+        color: inherit;
+        transition: transform 150ms ease, box-shadow 150ms ease;
+        box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+        border: 1px solid rgba(99, 102, 241, 0.12);
+        cursor: pointer;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .card:hover {
+        transform: translateY(-6px);
+        box-shadow: 0 18px 28px rgba(79, 70, 229, 0.18);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .card {
+          background: rgba(31, 41, 55, 0.9);
+          border-color: rgba(99, 102, 241, 0.2);
+          box-shadow: 0 10px 22px rgba(15, 23, 42, 0.6);
+        }
+      }
+
+      .card-title {
+        font-size: 1.25rem;
+        font-weight: 600;
+      }
+
+      .card-description {
+        font-size: 0.98rem;
+        color: var(--text-muted);
+      }
+
+      .badge {
+        align-self: flex-start;
+        padding: 0.3rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        letter-spacing: 0.02em;
+        background: rgba(99, 102, 241, 0.12);
+        color: var(--accent);
+        font-weight: 600;
+      }
+
+      .back-button {
+        appearance: none;
+        background: transparent;
+        border: none;
+        color: var(--accent);
+        font-weight: 600;
+        font-size: 0.95rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        cursor: pointer;
+        padding: 0.5rem 0;
+        margin-bottom: 1.5rem;
+      }
+
+      .back-button:hover {
+        text-decoration: underline;
+      }
+
+      .quiz-question {
+        padding: 1.25rem;
+        border-radius: 16px;
+        background: rgba(99, 102, 241, 0.08);
+        margin-bottom: 1rem;
+      }
+
+      .quiz-question h3 {
+        margin-top: 0;
+        margin-bottom: 0.75rem;
+      }
+
+      .options {
+        margin: 0;
+        padding-left: 1.2rem;
+      }
+
+      .options li + li {
+        margin-top: 0.35rem;
+      }
+
+      .answer {
+        margin-top: 0.75rem;
+        color: #059669;
+        font-weight: 600;
+      }
+
+      .htmx-indicator {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        background: rgba(15, 23, 42, 0.12);
+        opacity: 0;
+        transition: opacity 0.2s ease;
+      }
+
+      .htmx-indicator.htmx-request {
+        opacity: 1;
+      }
+
+      .spinner {
+        width: 48px;
+        height: 48px;
+        border: 4px solid rgba(99, 102, 241, 0.25);
+        border-top-color: var(--accent);
+        border-radius: 50%;
+        animation: spin 0.9s linear infinite;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="app-shell" hx-target="this">
+      <div id="content">
+        {% if active_view == "category" %}
+          {% include "category.html" %}
+        {% elif active_view == "quiz" %}
+          {% include "quiz.html" %}
+        {% else %}
+          <header>
+            <h1>Категории викторин</h1>
+            <p class="subtitle">Выберите тему, чтобы перейти к подборке викторин.</p>
+          </header>
+          <section class="grid">
+            {% for category in categories %}
+              <article
+                class="card"
+                hx-get="/category/{{ category.id }}"
+                hx-target="#content"
+                hx-push-url="true"
+                hx-indicator=".htmx-indicator"
+              >
+                <span class="badge">Категория</span>
+                <div class="card-title">{{ category.name }}</div>
+                <div class="card-description">{{ category.description }}</div>
+              </article>
+            {% endfor %}
+          </section>
+        {% endif %}
+      </div>
+      <div class="htmx-indicator">
+        <div class="spinner" aria-hidden="true"></div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/examples/htmx_preview/templates/index.html
+++ b/examples/htmx_preview/templates/index.html
@@ -105,6 +105,36 @@
           border-color: rgba(99, 102, 241, 0.2);
           box-shadow: 0 10px 22px rgba(15, 23, 42, 0.6);
         }
+
+        .notice {
+          background: rgba(248, 113, 113, 0.22);
+          border-color: rgba(248, 113, 113, 0.4);
+          color: #fca5a5;
+        }
+
+        .option {
+          background: rgba(31, 41, 55, 0.85);
+          border-color: rgba(148, 163, 184, 0.35);
+        }
+
+        .option.correct {
+          background: rgba(34, 197, 94, 0.25);
+          border-color: rgba(74, 222, 128, 0.5);
+          color: #4ade80;
+        }
+
+        .option-badge {
+          background: rgba(34, 197, 94, 0.35);
+          color: #bbf7d0;
+        }
+
+        .explanation {
+          color: #93c5fd;
+        }
+
+        .empty-state {
+          color: #94a3b8;
+        }
       }
 
       .card-title {
@@ -126,6 +156,23 @@
         background: rgba(99, 102, 241, 0.12);
         color: var(--accent);
         font-weight: 600;
+      }
+
+      .notice {
+        margin: 1.5rem 0;
+        padding: 1rem 1.25rem;
+        border-radius: 18px;
+        background: rgba(239, 68, 68, 0.12);
+        border: 1px solid rgba(248, 113, 113, 0.35);
+        color: #b91c1c;
+        font-weight: 600;
+      }
+
+      .empty-state {
+        margin: 2rem 0;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 1rem;
       }
 
       .back-button {
@@ -162,10 +209,43 @@
       .options {
         margin: 0;
         padding-left: 1.2rem;
+        list-style-position: inside;
       }
 
-      .options li + li {
-        margin-top: 0.35rem;
+      .option {
+        background: rgba(255, 255, 255, 0.6);
+        border-radius: 12px;
+        padding: 0.6rem 0.75rem;
+        margin: 0.45rem 0;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .option.correct {
+        border-color: rgba(34, 197, 94, 0.45);
+        background: rgba(34, 197, 94, 0.18);
+        color: #047857;
+        font-weight: 600;
+      }
+
+      .option-badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.1rem 0.45rem;
+        border-radius: 999px;
+        background: rgba(34, 197, 94, 0.25);
+        color: #047857;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .explanation {
+        margin-top: 0.75rem;
+        color: #2563eb;
+        font-size: 0.95rem;
       }
 
       .answer {
@@ -218,21 +298,28 @@
             <h1>Категории викторин</h1>
             <p class="subtitle">Выберите тему, чтобы перейти к подборке викторин.</p>
           </header>
-          <section class="grid">
-            {% for category in categories %}
-              <article
-                class="card"
-                hx-get="/category/{{ category.id }}"
-                hx-target="#content"
-                hx-push-url="true"
-                hx-indicator=".htmx-indicator"
-              >
-                <span class="badge">Категория</span>
-                <div class="card-title">{{ category.name }}</div>
-                <div class="card-description">{{ category.description }}</div>
-              </article>
-            {% endfor %}
-          </section>
+          {% if categories_error %}
+            <p class="notice">{{ categories_error }}</p>
+          {% endif %}
+          {% if categories %}
+            <section class="grid">
+              {% for category in categories %}
+                <article
+                  class="card"
+                  hx-get="/category/{{ category.id }}"
+                  hx-target="#content"
+                  hx-push-url="true"
+                  hx-indicator=".htmx-indicator"
+                >
+                  <span class="badge">Категория</span>
+                  <div class="card-title">{{ category.name }}</div>
+                  <div class="card-description">{{ category.description }}</div>
+                </article>
+              {% endfor %}
+            </section>
+          {% elif not categories_error %}
+            <p class="empty-state">Нет активных категорий для отображения.</p>
+          {% endif %}
         {% endif %}
       </div>
       <div class="htmx-indicator">

--- a/examples/htmx_preview/templates/quiz.html
+++ b/examples/htmx_preview/templates/quiz.html
@@ -1,26 +1,63 @@
-<button
-  class="back-button"
-  hx-get="/category/{{ current_category.id }}"
-  hx-target="#content"
-  hx-push-url="true"
-  hx-indicator=".htmx-indicator"
->
-  ← Назад к викторинам
-</button>
-<header>
-  <h1>{{ quiz.title }}</h1>
-  <p class="subtitle">Ниже представлен предварительный просмотр вопросов.</p>
-</header>
-<section>
-  {% for question in quiz.questions %}
-    <article class="quiz-question">
-      <h3>Вопрос {{ loop.index }}. {{ question.text }}</h3>
-      <ol class="options">
-        {% for option in question.options %}
-          <li>{{ option }}</li>
-        {% endfor %}
-      </ol>
-      <div class="answer">Правильный ответ: {{ question.answer }}</div>
-    </article>
-  {% endfor %}
-</section>
+{% if current_category %}
+  <button
+    class="back-button"
+    hx-get="/category/{{ current_category.id }}"
+    hx-target="#content"
+    hx-push-url="true"
+    hx-indicator=".htmx-indicator"
+  >
+    ← Назад к викторинам
+  </button>
+{% else %}
+  <button
+    class="back-button"
+    hx-get="/"
+    hx-target="#content"
+    hx-push-url="true"
+    hx-indicator=".htmx-indicator"
+  >
+    ← Назад к категориям
+  </button>
+{% endif %}
+
+{% if quiz_error %}
+  <p class="notice">{{ quiz_error }}</p>
+{% elif quiz %}
+  <header>
+    <h1>{{ quiz.title }}</h1>
+    <p class="subtitle">
+      {{ quiz.description or "Ниже представлен предварительный просмотр вопросов." }}
+    </p>
+  </header>
+  <section>
+    {% if quiz.questions %}
+      {% for question in quiz.questions %}
+        <article class="quiz-question">
+          <h3>Вопрос {{ loop.index }}. {{ question.text }}</h3>
+          {% if question.options %}
+            <ol class="options">
+              {% for option in question.options %}
+                <li class="option{% if option.is_correct %} correct{% endif %}">
+                  {{ option.text }}
+                  {% if option.is_correct %}
+                    <span class="option-badge">Верно</span>
+                  {% endif %}
+                </li>
+              {% endfor %}
+            </ol>
+          {% endif %}
+          {% if question.correct_answer %}
+            <div class="answer">Правильный ответ: {{ question.correct_answer }}</div>
+          {% endif %}
+          {% if question.explanation %}
+            <p class="explanation">{{ question.explanation }}</p>
+          {% endif %}
+        </article>
+      {% endfor %}
+    {% else %}
+      <p class="empty-state">Для этой викторины пока нет вопросов.</p>
+    {% endif %}
+  </section>
+{% else %}
+  <p class="empty-state">Викторина недоступна.</p>
+{% endif %}

--- a/examples/htmx_preview/templates/quiz.html
+++ b/examples/htmx_preview/templates/quiz.html
@@ -1,0 +1,26 @@
+<button
+  class="back-button"
+  hx-get="/category/{{ current_category.id }}"
+  hx-target="#content"
+  hx-push-url="true"
+  hx-indicator=".htmx-indicator"
+>
+  ← Назад к викторинам
+</button>
+<header>
+  <h1>{{ quiz.title }}</h1>
+  <p class="subtitle">Ниже представлен предварительный просмотр вопросов.</p>
+</header>
+<section>
+  {% for question in quiz.questions %}
+    <article class="quiz-question">
+      <h3>Вопрос {{ loop.index }}. {{ question.text }}</h3>
+      <ol class="options">
+        {% for option in question.options %}
+          <li>{{ option }}</li>
+        {% endfor %}
+      </ol>
+      <div class="answer">Правильный ответ: {{ question.answer }}</div>
+    </article>
+  {% endfor %}
+</section>


### PR DESCRIPTION
## Summary
- add a standalone FastAPI example that serves quiz categories, quizzes, and questions with HTMX navigation
- provide responsive templates with cards, back buttons, and a loading indicator for seamless transitions

## Testing
- python -m compileall examples/htmx_preview

------
https://chatgpt.com/codex/tasks/task_e_68dd0cbd1820832da5bcf048687468c4