### PR TITLE
Add interactive HTMX flow for quizzes

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -112,20 +112,58 @@
           color: #fca5a5;
         }
 
-        .option {
+        .quiz-step {
           background: rgba(31, 41, 55, 0.85);
-          border-color: rgba(148, 163, 184, 0.35);
+          border: 1px solid rgba(148, 163, 184, 0.35);
         }
 
-        .option.correct {
-          background: rgba(34, 197, 94, 0.25);
-          border-color: rgba(74, 222, 128, 0.5);
+        .option-button {
+          background: rgba(17, 24, 39, 0.9);
+          border-color: rgba(148, 163, 184, 0.3);
+          color: #e5e7eb;
+        }
+
+        .option-button:hover:not(:disabled) {
+          border-color: rgba(99, 102, 241, 0.6);
+          background: rgba(79, 70, 229, 0.18);
+        }
+
+        .option-button.is-correct {
+          background: rgba(34, 197, 94, 0.22);
+          border-color: rgba(74, 222, 128, 0.6);
           color: #4ade80;
         }
 
-        .option-badge {
-          background: rgba(34, 197, 94, 0.35);
+        .option-button.is-incorrect {
+          background: rgba(248, 113, 113, 0.22);
+          border-color: rgba(248, 113, 113, 0.5);
+          color: #fca5a5;
+        }
+
+        .answer-feedback.is-correct {
+          background: rgba(34, 197, 94, 0.18);
           color: #bbf7d0;
+        }
+
+        .answer-feedback.is-incorrect {
+          background: rgba(248, 113, 113, 0.18);
+          color: #fecaca;
+        }
+
+        .quiz-summary {
+          background: rgba(17, 24, 39, 0.9);
+          border-color: rgba(99, 102, 241, 0.25);
+        }
+
+        .back-to-categories,
+        .next-question {
+          background: rgba(99, 102, 241, 0.2);
+          color: #c7d2fe;
+        }
+
+        .back-to-categories:hover,
+        .next-question:hover {
+          background: rgba(129, 140, 248, 0.3);
         }
 
         .explanation {
@@ -194,64 +232,175 @@
         text-decoration: underline;
       }
 
-      .quiz-question {
-        padding: 1.25rem;
-        border-radius: 16px;
+      .quiz-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+      }
+
+      .quiz-step {
+        padding: 1.75rem;
+        border-radius: 18px;
         background: rgba(99, 102, 241, 0.08);
-        margin-bottom: 1rem;
+        border: 1px solid rgba(99, 102, 241, 0.15);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
       }
 
-      .quiz-question h3 {
-        margin-top: 0;
-        margin-bottom: 0.75rem;
+      .quiz-state {
+        display: none;
       }
 
-      .options {
+      .quiz-progress {
+        font-weight: 600;
+        color: var(--accent);
+        font-size: 0.95rem;
+        letter-spacing: 0.03em;
+      }
+
+      .quiz-question-title {
         margin: 0;
-        padding-left: 1.2rem;
-        list-style-position: inside;
+        font-size: 1.35rem;
+        line-height: 1.4;
       }
 
-      .option {
-        background: rgba(255, 255, 255, 0.6);
-        border-radius: 12px;
-        padding: 0.6rem 0.75rem;
-        margin: 0.45rem 0;
-        border: 1px solid rgba(148, 163, 184, 0.3);
+      .quiz-options {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .option-button {
         display: flex;
         align-items: center;
-        gap: 0.5rem;
+        gap: 0.75rem;
+        padding: 0.85rem 1rem;
+        border-radius: 14px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(255, 255, 255, 0.92);
+        font-size: 1rem;
+        text-align: left;
+        cursor: pointer;
+        transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
       }
 
-      .option.correct {
-        border-color: rgba(34, 197, 94, 0.45);
+      .option-button:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 22px rgba(99, 102, 241, 0.12);
+        border-color: rgba(99, 102, 241, 0.6);
+      }
+
+      .option-button:disabled {
+        cursor: default;
+        opacity: 0.85;
+      }
+
+      .option-button.is-correct {
+        border-color: rgba(34, 197, 94, 0.6);
         background: rgba(34, 197, 94, 0.18);
         color: #047857;
         font-weight: 600;
       }
 
-      .option-badge {
+      .option-button.is-incorrect {
+        border-color: rgba(248, 113, 113, 0.6);
+        background: rgba(248, 113, 113, 0.18);
+        color: #b91c1c;
+      }
+
+      .option-button.is-disabled {
+        opacity: 0.7;
+      }
+
+      .option-index {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        background: rgba(99, 102, 241, 0.18);
         display: inline-flex;
         align-items: center;
-        padding: 0.1rem 0.45rem;
-        border-radius: 999px;
+        justify-content: center;
+        font-weight: 600;
+        color: var(--accent);
+        flex-shrink: 0;
+      }
+
+      .option-button.is-correct .option-index {
         background: rgba(34, 197, 94, 0.25);
         color: #047857;
-        font-size: 0.7rem;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
+      }
+
+      .option-button.is-incorrect .option-index {
+        background: rgba(248, 113, 113, 0.2);
+        color: #b91c1c;
+      }
+
+      .option-text {
+        flex: 1;
+        display: inline-block;
+      }
+
+      .answer-feedback {
+        padding: 0.85rem 1rem;
+        border-radius: 12px;
+        font-weight: 600;
+      }
+
+      .answer-feedback.is-correct {
+        background: rgba(34, 197, 94, 0.16);
+        color: #047857;
+      }
+
+      .answer-feedback.is-incorrect {
+        background: rgba(248, 113, 113, 0.18);
+        color: #b91c1c;
       }
 
       .explanation {
-        margin-top: 0.75rem;
-        color: #2563eb;
+        margin: 0;
         font-size: 0.95rem;
+        color: #2563eb;
       }
 
-      .answer {
-        margin-top: 0.75rem;
-        color: #059669;
+      .quiz-actions {
+        display: flex;
+        justify-content: flex-end;
+      }
+
+      .next-question,
+      .back-to-categories {
+        appearance: none;
+        border: none;
+        border-radius: 999px;
+        padding: 0.65rem 1.4rem;
+        background: rgba(99, 102, 241, 0.18);
+        color: var(--accent);
         font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease;
+      }
+
+      .next-question:hover,
+      .back-to-categories:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 20px rgba(99, 102, 241, 0.18);
+        background: rgba(99, 102, 241, 0.28);
+      }
+
+      .quiz-summary {
+        margin-top: 0.5rem;
+        padding: 1.25rem;
+        border-radius: 16px;
+        background: rgba(99, 102, 241, 0.12);
+        border: 1px solid rgba(99, 102, 241, 0.22);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .quiz-summary h3 {
+        margin: 0;
       }
 
       .htmx-indicator {

--- a/webapp/templates/quiz.html
+++ b/webapp/templates/quiz.html
@@ -1,63 +1,57 @@
-{% if current_category %}
-  <button
-    class="back-button"
-    hx-get="/category/{{ current_category.id }}"
-    hx-target="#content"
-    hx-push-url="true"
-    hx-indicator=".htmx-indicator"
-  >
-    ← Назад к викторинам
-  </button>
-{% else %}
-  <button
-    class="back-button"
-    hx-get="/"
-    hx-target="#content"
-    hx-push-url="true"
-    hx-indicator=".htmx-indicator"
-  >
-    ← Назад к категориям
-  </button>
-{% endif %}
+<div class="quiz-wrapper">
+  {% if current_category %}
+    <button
+      class="back-button"
+      hx-get="/category/{{ current_category.id }}"
+      hx-target="#content"
+      hx-push-url="true"
+      hx-indicator=".htmx-indicator"
+    >
+      ← Назад к викторинам
+    </button>
+  {% else %}
+    <button
+      class="back-button"
+      hx-get="/"
+      hx-target="#content"
+      hx-push-url="true"
+      hx-indicator=".htmx-indicator"
+    >
+      ← Назад к категориям
+    </button>
+  {% endif %}
 
-{% if quiz_error %}
-  <p class="notice">{{ quiz_error }}</p>
-{% elif quiz %}
-  <header>
-    <h1>{{ quiz.title }}</h1>
-    <p class="subtitle">
-      {{ quiz.description or "Ниже представлен предварительный просмотр вопросов." }}
-    </p>
-  </header>
-  <section>
+  {% if quiz_error %}
+    <p class="notice">{{ quiz_error }}</p>
+  {% elif quiz %}
+    <header>
+      <h1>{{ quiz.title }}</h1>
+      <p class="subtitle">
+        {{ quiz.description or "Отвечайте на вопросы по одному и следите за прогрессом." }}
+      </p>
+    </header>
+
     {% if quiz.questions %}
-      {% for question in quiz.questions %}
-        <article class="quiz-question">
-          <h3>Вопрос {{ loop.index }}. {{ question.text }}</h3>
-          {% if question.options %}
-            <ol class="options">
-              {% for option in question.options %}
-                <li class="option{% if option.is_correct %} correct{% endif %}">
-                  {{ option.text }}
-                  {% if option.is_correct %}
-                    <span class="option-badge">Верно</span>
-                  {% endif %}
-                </li>
-              {% endfor %}
-            </ol>
-          {% endif %}
-          {% if question.correct_answer %}
-            <div class="answer">Правильный ответ: {{ question.correct_answer }}</div>
-          {% endif %}
-          {% if question.explanation %}
-            <p class="explanation">{{ question.explanation }}</p>
-          {% endif %}
-        </article>
-      {% endfor %}
+      {% set total_questions = quiz.questions | length %}
+      {% set first_question = quiz.questions[0] %}
+      {% set next_question_id = total_questions > 1 and quiz.questions[1].id or None %}
+      {% include "quiz_question.html" with
+        quiz_id=quiz.id,
+        quiz=quiz,
+        question=first_question,
+        current_question_index=1,
+        total_questions=total_questions,
+        correct_count=0,
+        answered_count=0,
+        show_result=False,
+        selected_option_id=None,
+        next_question_id=next_question_id,
+        quiz_completed=False
+      %}
     {% else %}
       <p class="empty-state">Для этой викторины пока нет вопросов.</p>
     {% endif %}
-  </section>
-{% else %}
-  <p class="empty-state">Викторина недоступна.</p>
-{% endif %}
+  {% else %}
+    <p class="empty-state">Викторина недоступна.</p>
+  {% endif %}
+</div>

--- a/webapp/templates/quiz_question.html
+++ b/webapp/templates/quiz_question.html
@@ -1,0 +1,73 @@
+<div id="quiz-body" class="quiz-step">
+  <form class="quiz-state">
+    <input type="hidden" name="correct_count" value="{{ correct_count }}" />
+    <input type="hidden" name="answered_count" value="{{ answered_count }}" />
+  </form>
+  <div class="quiz-progress">Вопрос {{ current_question_index }} из {{ total_questions }}</div>
+  <h2 class="quiz-question-title">{{ question.text }}</h2>
+  {% if question.options %}
+    <div class="quiz-options">
+      {% for option in question.options %}
+        {% set is_selected = selected_option_id is not none and option.id == selected_option_id %}
+        {% set is_correct_option = question.correct_option_id is not none and option.id == question.correct_option_id %}
+        <button
+          type="button"
+          class="option-button{% if show_result and is_correct_option %} is-correct{% endif %}{% if show_result and is_selected and not is_correct_option %} is-incorrect{% endif %}"
+          hx-post="/quiz/{{ quiz_id }}/answer/{{ question.id }}"
+          hx-target="#quiz-body"
+          hx-swap="outerHTML"
+          hx-include="#quiz-body form.quiz-state"
+          hx-vals='{"option_id": {{ option.id }}}'
+          hx-indicator=".htmx-indicator"
+          {% if show_result %}disabled{% endif %}
+        >
+          <span class="option-index">{{ loop.index }}</span>
+          <span class="option-text">{{ option.text }}</span>
+        </button>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  {% if show_result %}
+    <div class="answer-feedback{% if is_correct %} is-correct{% else %} is-incorrect{% endif %}">
+      {% if is_correct %}
+        👍 Верно! Молодец.
+      {% else %}
+        ❌ Неверно. Попробуйте в следующий раз.
+      {% endif %}
+    </div>
+    {% if question.explanation %}
+      <p class="explanation">{{ question.explanation }}</p>
+    {% endif %}
+    {% if quiz_completed %}
+      <div class="quiz-summary">
+        <h3>Результат</h3>
+        <p>Вы ответили правильно на {{ correct_count }} из {{ total_questions }} вопросов.</p>
+        <button
+          type="button"
+          class="back-to-categories"
+          hx-get="/"
+          hx-target="#content"
+          hx-push-url="true"
+          hx-indicator=".htmx-indicator"
+        >
+          Вернуться к категориям
+        </button>
+      </div>
+    {% elif next_question_id %}
+      <div class="quiz-actions">
+        <button
+          type="button"
+          class="next-question"
+          hx-get="/quiz/{{ quiz_id }}/question/{{ next_question_id }}"
+          hx-target="#quiz-body"
+          hx-swap="outerHTML"
+          hx-include="#quiz-body form.quiz-state"
+          hx-indicator=".htmx-indicator"
+        >
+          Следующий вопрос
+        </button>
+      </div>
+    {% endif %}
+  {% endif %}
+</div>

--- a/webapp/templates/quiz_result.html
+++ b/webapp/templates/quiz_result.html
@@ -1,0 +1,49 @@
+<div id="quiz-body" class="quiz-step">
+  {% if last_question %}
+    <div class="quiz-progress">Вопрос {{ last_question_index or 1 }} из {{ total_questions }}</div>
+    <h2 class="quiz-question-title">{{ last_question.text }}</h2>
+    {% if last_question.options %}
+      <div class="quiz-options">
+        {% for option in last_question.options %}
+          {% set is_selected = selected_option_id is not none and option.id == selected_option_id %}
+          {% set is_correct_option = last_question.correct_option_id is not none and option.id == last_question.correct_option_id %}
+          <button
+            type="button"
+            class="option-button is-disabled{% if is_correct_option %} is-correct{% endif %}{% if is_selected and not is_correct_option %} is-incorrect{% endif %}"
+            disabled
+          >
+            <span class="option-index">{{ loop.index }}</span>
+            <span class="option-text">{{ option.text }}</span>
+          </button>
+        {% endfor %}
+      </div>
+    {% endif %}
+    {% if is_correct is not none %}
+      <div class="answer-feedback{% if is_correct %} is-correct{% else %} is-incorrect{% endif %}">
+        {% if is_correct %}
+          👍 Верно! Молодец.
+        {% else %}
+          ❌ Неверно. Попробуйте в следующий раз.
+        {% endif %}
+      </div>
+    {% endif %}
+    {% if last_question.explanation %}
+      <p class="explanation">{{ last_question.explanation }}</p>
+    {% endif %}
+  {% endif %}
+
+  <div class="quiz-summary">
+    <h3>Результат</h3>
+    <p>Вы ответили правильно на {{ correct_count }} из {{ total_questions }} вопросов.</p>
+    <button
+      type="button"
+      class="back-to-categories"
+      hx-get="/"
+      hx-target="#content"
+      hx-push-url="true"
+      hx-indicator=".htmx-indicator"
+    >
+      Вернуться к категориям
+    </button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- show quiz questions one at a time with HTMX-powered answer handling and navigation
- add API endpoints to validate answers, return next questions, and render the final result
- refresh quiz styling to support interactive buttons and the results screen

## Testing
- python -m compileall webapp

------
https://chatgpt.com/codex/tasks/task_e_68dd37f1a2ec832dbfe8a86018421c5a