### PR TITLE
Restyle category chips and quiz cards

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -99,7 +99,7 @@
 
       .categories-scroll {
         display: flex;
-        gap: 0.75rem;
+        gap: 0.5rem;
         overflow-x: auto;
         padding-bottom: 0.25rem;
         margin: 0 -0.5rem;
@@ -112,54 +112,60 @@
       }
 
       .category-chip {
+        appearance: none;
+        border: none;
         position: relative;
         display: inline-flex;
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 0.25rem;
-        padding: 0.75rem 1.1rem;
-        border-radius: 16px;
-        border: 1px solid var(--chip-border);
-        background: var(--chip-bg);
-        color: inherit;
+        align-items: center;
+        justify-content: center;
+        padding: 0.45rem 1.1rem;
+        border-radius: 999px;
+        background: #7c3aed;
+        color: #ffffff;
         cursor: pointer;
-        min-width: 160px;
-        max-width: 220px;
-        scroll-snap-align: center;
-        transition: transform 0.2s ease, border-color 0.2s ease,
-          box-shadow 0.2s ease, background 0.2s ease;
-        font-size: 0.95rem;
+        font-weight: 600;
+        font-size: 0.9rem;
+        letter-spacing: 0.01em;
+        white-space: nowrap;
+        flex: 0 0 auto;
+        scroll-snap-align: start;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+        box-shadow: 0 10px 20px rgba(76, 29, 149, 0.25);
       }
 
       .category-chip:hover {
         transform: translateY(-2px);
-        border-color: var(--accent);
-        box-shadow: 0 14px 28px rgba(99, 102, 241, 0.18);
+        box-shadow: 0 14px 28px rgba(76, 29, 149, 0.3);
       }
 
       .category-chip:focus-visible {
-        outline: 2px solid var(--accent);
+        outline: 2px solid rgba(255, 255, 255, 0.85);
         outline-offset: 3px;
       }
 
       .category-chip.is-active {
-        background: linear-gradient(145deg, rgba(99, 102, 241, 0.18), rgba(79, 70, 229, 0.28));
-        color: var(--accent-strong);
-        border-color: rgba(79, 70, 229, 0.45);
-        box-shadow: 0 14px 28px rgba(79, 70, 229, 0.24);
+        transform: translateY(-2px);
+        box-shadow: 0 16px 32px rgba(76, 29, 149, 0.32);
+        opacity: 1;
+      }
+
+      .category-chip:nth-of-type(3n + 1) {
+        background: linear-gradient(135deg, #7c3aed, #6d28d9);
+        box-shadow: 0 10px 20px rgba(76, 29, 149, 0.28);
+      }
+
+      .category-chip:nth-of-type(3n + 2) {
+        background: linear-gradient(135deg, #2563eb, #1d4ed8);
+        box-shadow: 0 10px 20px rgba(29, 78, 216, 0.28);
+      }
+
+      .category-chip:nth-of-type(3n) {
+        background: linear-gradient(135deg, #10b981, #059669);
+        box-shadow: 0 10px 20px rgba(5, 150, 105, 0.28);
       }
 
       .category-chip__title {
-        font-weight: 600;
-        font-size: 0.95rem;
-        line-height: 1.4;
-      }
-
-      .category-chip__desc {
-        margin: 0;
-        color: var(--text-muted);
-        font-size: 0.8rem;
-        line-height: 1.4;
+        line-height: 1.2;
       }
 
       .category-summary {
@@ -185,48 +191,48 @@
 
       .quiz-grid {
         display: grid;
-        grid-template-columns: repeat(2, minmax(180px, 1fr));
-        gap: clamp(1rem, 2.5vw, 1.75rem);
-        overflow-x: auto;
-        padding-bottom: 0.25rem;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 1.35rem;
       }
 
       .quiz-card {
-        background: rgba(255, 255, 255, 0.88);
-        border-radius: 20px;
-        padding: 1.4rem;
-        border: 1px solid var(--card-border);
+        background: #ffffff;
+        border-radius: 18px;
+        padding: 1.25rem;
+        border: none;
         display: flex;
         flex-direction: column;
-        justify-content: space-between;
-        gap: 1.25rem;
-        min-height: 220px;
-        transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+        gap: 0.75rem;
+        min-height: 0;
+        box-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
       }
 
       .quiz-card:hover {
-        transform: translateY(-4px);
-        border-color: rgba(99, 102, 241, 0.32);
-        box-shadow: 0 22px 40px rgba(15, 23, 42, 0.15);
+        transform: translateY(-3px);
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
       }
 
       .quiz-card__title {
         margin: 0;
-        font-size: 1.1rem;
-        line-height: 1.45;
+        font-size: 1.05rem;
+        line-height: 1.4;
+        font-weight: 700;
+        color: var(--text);
       }
 
       .quiz-card__description {
         margin: 0;
-        color: var(--text-muted);
-        line-height: 1.55;
-        font-size: 0.95rem;
+        color: #6b7280;
+        line-height: 1.5;
+        font-size: 0.9rem;
       }
 
       .quiz-card__actions {
         display: flex;
-        justify-content: space-between;
+        justify-content: flex-start;
         align-items: center;
+        margin-top: auto;
       }
 
       .quiz-card__action {
@@ -495,24 +501,19 @@
         }
       }
 
-      @media (max-width: 900px) {
-        .quiz-card {
-          min-height: 200px;
-        }
-      }
-
       @media (max-width: 768px) {
         body {
           padding: clamp(0.75rem, 2vw, 1.5rem);
         }
 
         .quiz-grid {
-          grid-template-columns: repeat(2, minmax(170px, 1fr));
-          gap: 1.25rem;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 1rem;
         }
 
         .category-chip {
-          min-width: 150px;
+          font-size: 0.85rem;
+          padding-inline: 1rem;
         }
       }
 
@@ -523,7 +524,7 @@
         }
 
         .quiz-grid {
-          grid-template-columns: repeat(2, minmax(160px, 1fr));
+          grid-template-columns: 1fr;
         }
 
         .quiz-card {
@@ -532,26 +533,9 @@
       }
 
       @media (max-width: 420px) {
-        .quiz-grid {
-          display: grid;
-          grid-auto-flow: column;
-          grid-auto-columns: minmax(160px, 1fr);
-          overflow-x: auto;
-          padding-bottom: 0.4rem;
-        }
-
-        .quiz-grid::-webkit-scrollbar {
-          display: none;
-        }
-
-        .quiz-card {
-          min-height: 210px;
-        }
-      }
-
-      @media (min-width: 1024px) {
-        .quiz-grid {
-          grid-template-columns: repeat(4, minmax(0, 1fr));
+        .category-chip {
+          font-size: 0.8rem;
+          padding: 0.4rem 0.9rem;
         }
       }
 
@@ -569,21 +553,15 @@
         }
 
         .home-header__subtitle,
-        .category-chip__desc,
         .category-summary__description,
         .quiz-card__description,
         .empty-state {
           color: rgba(148, 163, 184, 0.95);
         }
 
-        .category-chip {
-          background: rgba(15, 23, 42, 0.85);
-          border-color: rgba(79, 70, 229, 0.35);
-        }
-
         .quiz-card {
           background: rgba(15, 23, 42, 0.9);
-          border-color: rgba(99, 102, 241, 0.2);
+          box-shadow: 0 18px 40px rgba(2, 6, 23, 0.55);
         }
 
         .notice {

--- a/webapp/templates/partials/home.html
+++ b/webapp/templates/partials/home.html
@@ -32,7 +32,6 @@
           hx-indicator=".htmx-indicator"
         >
           <span class="category-chip__title">{{ category.name }}</span>
-          <span class="category-chip__desc">{{ category.description }}</span>
         </button>
       {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- restyle the category selector into compact colorful chips that only show the category name
- update the quiz list layout to present white two-per-row cards with bolder titles and muted descriptions
- tune responsive and dark-mode styles to match the new presentation

## Testing
- not run (uvicorn startup requires python-multipart and package installation is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd7e774d74832d8dd16c4531f8bbcc