### PR TITLE
Fix category summary refresh when switching categories

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -339,7 +339,7 @@ async def read_category_quizzes(
         "quizzes": quizzes,
         "quizzes_error": quizzes_error,
     }
-    return templates.TemplateResponse("partials/quiz_list.html", context)
+    return templates.TemplateResponse("partials/category_panel.html", context)
 
 
 @app.get("/quiz/{quiz_id}", response_class=HTMLResponse)

--- a/webapp/templates/partials/category_panel.html
+++ b/webapp/templates/partials/category_panel.html
@@ -1,0 +1,12 @@
+{% if selected_category %}
+  <section class="category-summary">
+    <h2 class="category-summary__title">{{ selected_category.name }}</h2>
+    <p class="category-summary__description">{{ selected_category.description }}</p>
+  </section>
+{% else %}
+  <p class="empty-state">Выберите категорию, чтобы увидеть доступные викторины.</p>
+{% endif %}
+
+<section id="quiz-list">
+  {% include "partials/quiz_list.html" %}
+</section>

--- a/webapp/templates/partials/home.html
+++ b/webapp/templates/partials/home.html
@@ -26,7 +26,7 @@
           role="tab"
           aria-selected="{{ 'true' if category.id == selected_category_id else 'false' }}"
           hx-get="/category/{{ category.id }}/quizzes"
-          hx-target="#quiz-list"
+          hx-target="#category-panel"
           hx-swap="innerHTML"
           hx-push-url="/?category={{ category.id }}"
           hx-indicator=".htmx-indicator"
@@ -40,13 +40,6 @@
   <p class="empty-state">Нет активных категорий для отображения.</p>
 {% endif %}
 
-{% if selected_category %}
-  <section class="category-summary">
-    <h2 class="category-summary__title">{{ selected_category.name }}</h2>
-    <p class="category-summary__description">{{ selected_category.description }}</p>
-  </section>
-{% endif %}
-
-<section id="quiz-list">
-  {% include "partials/quiz_list.html" %}
-</section>
+<div id="category-panel">
+  {% include "partials/category_panel.html" %}
+</div>


### PR DESCRIPTION
## Summary
- add a category panel partial that renders both the summary and quiz list together
- retarget HTMX category chip requests to refresh the new panel
- update the FastAPI handler to serve the combined panel partial

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd820eb5cc832d8932e05ee49e1453