### PR TITLE
Keep the category bar fixed under the quiz header

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -24,6 +24,8 @@
         --chip-border: rgba(99, 102, 241, 0.35);
         --card-border: rgba(15, 23, 42, 0.08);
         --shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+        --surface-padding: clamp(1.5rem, 3.5vw, 3rem);
+        --category-bar-height: clamp(4rem, 3.5rem + 1vw, 4.75rem);
       }
 
       * {
@@ -51,17 +53,86 @@
       .layout__surface {
         background: var(--bg-surface);
         border-radius: clamp(18px, 3vw, 28px);
-        padding: clamp(1.5rem, 3.5vw, 3rem);
+        padding: var(--surface-padding);
         box-shadow: var(--shadow);
         position: relative;
         overflow: hidden;
         backdrop-filter: blur(18px);
+        display: flex;
+        flex-direction: column;
+      }
+
+      .layout__surface:has(.home-view) {
+        max-height: calc(100vh - var(--surface-padding) * 2);
       }
 
       #content {
         display: flex;
         flex-direction: column;
         gap: clamp(1.5rem, 3vw, 2.75rem);
+        flex: 1;
+        min-height: 0;
+      }
+
+      .home-view {
+        display: flex;
+        flex-direction: column;
+        gap: clamp(1.25rem, 2.5vw, 2rem);
+        flex: 1;
+        min-height: 0;
+      }
+
+      .home-view__pinned {
+        position: sticky;
+        top: var(--surface-padding);
+        z-index: 5;
+        display: flex;
+        flex-direction: column;
+        gap: clamp(1rem, 2vw, 1.5rem);
+        padding-bottom: clamp(1rem, 2vw, 1.4rem);
+        background: var(--bg-surface);
+        flex-shrink: 0;
+      }
+
+      .home-view__content {
+        display: flex;
+        flex-direction: column;
+        gap: clamp(1.25rem, 2.5vw, 2rem);
+        flex: 1;
+        min-height: 0;
+      }
+
+      .category-panel {
+        display: flex;
+        flex-direction: column;
+        gap: clamp(1.25rem, 2.5vw, 2rem);
+        flex: 1;
+        min-height: 0;
+      }
+
+      .category-panel__header {
+        flex-shrink: 0;
+      }
+
+      .category-panel__scroller {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        padding-right: 0.25rem;
+        margin-right: -0.25rem;
+        max-height: max(
+          15rem,
+          calc(100vh - var(--surface-padding) * 2 - var(--category-bar-height) - clamp(6rem, 8vw, 8rem))
+        );
+      }
+
+      .category-panel__scroller::-webkit-scrollbar {
+        width: 6px;
+      }
+
+      .category-panel__scroller::-webkit-scrollbar-thumb {
+        background: rgba(99, 102, 241, 0.25);
+        border-radius: 999px;
       }
 
       .home-header__eyebrow {
@@ -94,7 +165,12 @@
       .categories-section {
         display: flex;
         flex-direction: column;
-        gap: 1rem;
+        justify-content: center;
+        gap: 0.75rem;
+        height: var(--category-bar-height);
+        min-height: var(--category-bar-height);
+        max-height: var(--category-bar-height);
+        flex-shrink: 0;
       }
 
       .categories-scroll {

--- a/webapp/templates/partials/category_panel.html
+++ b/webapp/templates/partials/category_panel.html
@@ -1,12 +1,16 @@
-{% if selected_category %}
-  <section class="category-summary">
-    <h2 class="category-summary__title">{{ selected_category.name }}</h2>
-    <p class="category-summary__description">{{ selected_category.description }}</p>
-  </section>
-{% else %}
-  <p class="empty-state">Выберите категорию, чтобы увидеть доступные викторины.</p>
-{% endif %}
+<div class="category-panel__header">
+  {% if selected_category %}
+    <section class="category-summary">
+      <h2 class="category-summary__title">{{ selected_category.name }}</h2>
+      <p class="category-summary__description">{{ selected_category.description }}</p>
+    </section>
+  {% else %}
+    <p class="empty-state">Выберите категорию, чтобы увидеть доступные викторины.</p>
+  {% endif %}
+</div>
 
-<section id="quiz-list">
-  {% include "partials/quiz_list.html" %}
-</section>
+<div class="category-panel__scroller" role="region" aria-live="polite">
+  <section id="quiz-list">
+    {% include "partials/quiz_list.html" %}
+  </section>
+</div>

--- a/webapp/templates/partials/home.html
+++ b/webapp/templates/partials/home.html
@@ -1,40 +1,48 @@
-<section class="home-header">
-  <span class="home-header__eyebrow">Подборка викторин</span>
-</section>
+<div class="home-view">
+  <div class="home-view__pinned">
+    <section class="home-header">
+      <span class="home-header__eyebrow">Подборка викторин</span>
+    </section>
 
-{% if categories_error %}
-  <p class="notice">{{ categories_error }}</p>
-{% endif %}
+    {% if categories_error %}
+      <p class="notice">{{ categories_error }}</p>
+    {% endif %}
 
-{% if categories %}
-  <section class="categories-section">
-    <div
-      class="categories-scroll"
-      role="tablist"
-      aria-label="Категории викторин"
-      data-category-bar
-    >
-      {% for category in categories %}
-        <button
-          type="button"
-          class="category-chip{% if category.id == selected_category_id %} is-active{% endif %}"
-          role="tab"
-          aria-selected="{{ 'true' if category.id == selected_category_id else 'false' }}"
-          hx-get="/category/{{ category.id }}/quizzes"
-          hx-target="#category-panel"
-          hx-swap="innerHTML"
-          hx-push-url="/?category={{ category.id }}"
-          hx-indicator=".htmx-indicator"
+    {% if categories %}
+      <section class="categories-section">
+        <div
+          class="categories-scroll"
+          role="tablist"
+          aria-label="Категории викторин"
+          data-category-bar
         >
-          <span class="category-chip__title">{{ category.name }}</span>
-        </button>
-      {% endfor %}
-    </div>
-  </section>
-{% else %}
-  <p class="empty-state">Нет активных категорий для отображения.</p>
-{% endif %}
+          {% for category in categories %}
+            <button
+              type="button"
+              class="category-chip{% if category.id == selected_category_id %} is-active{% endif %}"
+              role="tab"
+              aria-selected="{{ 'true' if category.id == selected_category_id else 'false' }}"
+              hx-get="/category/{{ category.id }}/quizzes"
+              hx-target="#category-panel"
+              hx-swap="innerHTML"
+              hx-push-url="/?category={{ category.id }}"
+              hx-indicator=".htmx-indicator"
+            >
+              <span class="category-chip__title">{{ category.name }}</span>
+            </button>
+          {% endfor %}
+        </div>
+      </section>
+    {% endif %}
+  </div>
 
-<div id="category-panel">
-  {% include "partials/category_panel.html" %}
+  <div class="home-view__content">
+    <div id="category-panel" class="category-panel">
+      {% if categories %}
+        {% include "partials/category_panel.html" %}
+      {% else %}
+        <p class="empty-state">Нет активных категорий для отображения.</p>
+      {% endif %}
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- restructure the home view markup to wrap the header, category bar, and quiz panel with dedicated layout containers
- add sticky positioning and fixed sizing styles so the category bar stays pinned beneath the header with a consistent height
- introduce a scrollable quiz list region to keep quiz cards scrolling independently of the pinned controls

## Testing
- uvicorn webapp.main:app --host 0.0.0.0 --port 8000

------
https://chatgpt.com/codex/tasks/task_e_68de2c82d81c832db44f8c46026c0040