### PR TITLE
Fix category bar height across devices

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -25,7 +25,7 @@
         --card-border: rgba(15, 23, 42, 0.08);
         --shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
         --surface-padding: clamp(1.5rem, 3.5vw, 3rem);
-        --category-bar-height: clamp(4rem, 3.5rem + 1vw, 4.75rem);
+        --category-bar-height: 5rem;
       }
 
       * {
@@ -578,6 +578,16 @@
       }
 
       @media (max-width: 768px) {
+        :root {
+          --category-bar-height: 5rem;
+        }
+
+        .categories-section {
+          height: var(--category-bar-height);
+          min-height: var(--category-bar-height);
+          max-height: var(--category-bar-height);
+        }
+
         body {
           padding: clamp(0.75rem, 2vw, 1.5rem);
         }


### PR DESCRIPTION
## Summary
- lock the category bar height to a fixed value instead of a responsive clamp
- enforce the same fixed height inside the mobile media query to prevent shrinking when few quizzes are available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de84ff426c832db070e0c922c7f51a