### PR TITLE
Add Telegram login support to webapp

### DIFF
--- a/webapp/auth/__init__.py
+++ b/webapp/auth/__init__.py
@@ -1,0 +1,15 @@
+"""Authentication utilities for the web application."""
+
+from .telegram import (
+    get_or_create_user,
+    get_user_from_supabase,
+    router,
+    verify_telegram_signature,
+)
+
+__all__ = [
+    "get_or_create_user",
+    "get_user_from_supabase",
+    "router",
+    "verify_telegram_signature",
+]

--- a/webapp/auth/telegram.py
+++ b/webapp/auth/telegram.py
@@ -1,0 +1,175 @@
+"""Telegram authentication helpers and API endpoints."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from starlette.concurrency import run_in_threadpool
+
+from config import BOT_TOKEN
+from supabase_client import supabase
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class TelegramLoginPayload(BaseModel):
+    """Payload received from the Telegram Login Widget."""
+
+    id: int
+    username: Optional[str] = None
+    first_name: Optional[str] = None
+    hash: str
+    auth_date: Optional[int] = None
+    last_name: Optional[str] = None
+    photo_url: Optional[str] = None
+
+
+def verify_telegram_signature(
+    data: Dict[str, Any],
+    bot_token: Optional[str] = None,
+    *,
+    expected_hash: str,
+) -> bool:
+    """Verify Telegram Login Widget payload signature using HMAC-SHA256."""
+
+    token = bot_token or BOT_TOKEN
+    if not token:
+        raise RuntimeError("BOT_TOKEN is not configured for Telegram authentication")
+
+    filtered_data = {k: v for k, v in data.items() if k != "hash"}
+    data_check_string = "\n".join(
+        f"{key}={value}" for key, value in sorted(filtered_data.items())
+    )
+
+    secret_key = hashlib.sha256(token.encode()).digest()
+    computed_hash = hmac.new(secret_key, data_check_string.encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(computed_hash, expected_hash)
+
+
+async def get_user_from_supabase(user_id: int) -> Optional[Dict[str, Any]]:
+    """Retrieve a user record from Supabase by Telegram identifier."""
+
+    def _query() -> Optional[Dict[str, Any]]:
+        response = (
+            supabase.table("users")
+            .select("id,username,first_name")
+            .eq("id", user_id)
+            .limit(1)
+            .execute()
+        )
+        if not response.data:
+            return None
+        return response.data[0]
+
+    try:
+        return await run_in_threadpool(_query)
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.exception("Failed to fetch user from Supabase", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Не удалось получить данные пользователя",
+        ) from exc
+
+
+async def get_or_create_user(
+    user_id: int,
+    username: Optional[str] = None,
+    first_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get a user from Supabase or create a new record if absent."""
+
+    existing = await get_user_from_supabase(user_id)
+    if existing is not None:
+        return existing
+
+    payload = {"id": user_id}
+    if username is not None:
+        payload["username"] = username
+    if first_name is not None:
+        payload["first_name"] = first_name
+
+    def _insert() -> Dict[str, Any]:
+        response = supabase.table("users").insert(payload).execute()
+        if response.data:
+            return response.data[0]
+        return payload
+
+    try:
+        return await run_in_threadpool(_insert)
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.exception("Failed to create user in Supabase", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Не удалось сохранить пользователя",
+        ) from exc
+
+
+@router.post("/login")
+async def login(payload: TelegramLoginPayload, response: Response) -> Dict[str, Any]:
+    """Authenticate user via Telegram Login Widget data."""
+
+    payload_dict = payload.model_dump(exclude_none=True)
+    provided_hash = payload_dict.pop("hash", None)
+    if not provided_hash:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Отсутствует подпись hash",
+        )
+
+    if not verify_telegram_signature(payload_dict, expected_hash=provided_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Некорректная подпись Telegram",
+        )
+
+    user = await get_or_create_user(
+        user_id=payload.id,
+        username=payload.username,
+        first_name=payload.first_name,
+    )
+
+    response.set_cookie(
+        key="user_id",
+        value=str(user["id"]),
+        httponly=True,
+        max_age=60 * 60 * 24 * 30,
+        samesite="lax",
+    )
+
+    return {"status": "ok", "user": user}
+
+
+@router.get("/me")
+async def read_current_user(request: Request) -> Dict[str, Any]:
+    """Return the current authenticated user based on the cookie."""
+
+    raw_user_id = request.cookies.get("user_id")
+    if raw_user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Пользователь не авторизован",
+        )
+
+    try:
+        user_id = int(raw_user_id)
+    except (TypeError, ValueError) as exc:
+        logger.warning("Invalid user_id cookie received", exc_info=exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Некорректный идентификатор пользователя",
+        ) from exc
+
+    user = await get_user_from_supabase(user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Пользователь не найден",
+        )
+
+    return {"user": user}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -162,6 +162,39 @@
         line-height: 1.6;
       }
 
+      .home-header__auth {
+        margin-top: 1.25rem;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .telegram-login-button {
+        appearance: none;
+        border: none;
+        border-radius: 999px;
+        background: var(--accent);
+        color: #ffffff;
+        padding: 0.6rem 1.4rem;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 10px 25px rgba(99, 102, 241, 0.2);
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      }
+
+      .telegram-login-button:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 28px rgba(99, 102, 241, 0.24);
+        background: var(--accent-strong);
+      }
+
+      .telegram-login-button:disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+        box-shadow: none;
+      }
+
       .categories-section {
         display: flex;
         flex-direction: column;
@@ -696,6 +729,37 @@
         </div>
       </div>
     </main>
+    <script>
+      window.onTelegramAuth = function (user) {
+        fetch("/login", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(user || {}),
+        })
+          .then(function (response) {
+            if (!response.ok) {
+              return response
+                .json()
+                .catch(function () {
+                  return {};
+                })
+                .then(function (payload) {
+                  var message = payload && payload.detail ? payload.detail : "Не удалось выполнить вход через Telegram.";
+                  throw new Error(message);
+                });
+            }
+            return response.json();
+          })
+          .then(function () {
+            window.location.reload();
+          })
+          .catch(function (error) {
+            console.error("Telegram login error", error);
+            window.alert(error.message || "Не удалось выполнить вход через Telegram.");
+          });
+      };
+    </script>
     <script>
       (function () {
         function scrollActiveChip(container) {

--- a/webapp/templates/partials/home.html
+++ b/webapp/templates/partials/home.html
@@ -2,6 +2,30 @@
   <div class="home-view__pinned">
     <section class="home-header">
       <span class="home-header__eyebrow">Подборка викторин</span>
+      {% if current_user %}
+        <h1 class="home-header__title">Привет, {{ current_user.first_name or current_user.username or 'друг' }}!</h1>
+        <p class="home-header__subtitle">Готов продолжить викторины? Выбери категорию ниже.</p>
+      {% else %}
+        <h1 class="home-header__title">Готовы проверить свои знания?</h1>
+        <p class="home-header__subtitle">Авторизуйтесь через Telegram, чтобы сохранять прогресс и участвовать в рейтингах.</p>
+        <div class="home-header__auth">
+          {% if telegram_bot_username %}
+            <script
+              async
+              src="https://telegram.org/js/telegram-widget.js?22"
+              data-telegram-login="{{ telegram_bot_username }}"
+              data-size="large"
+              data-userpic="false"
+              data-onauth="onTelegramAuth(user)"
+              data-request-access="write"
+            ></script>
+          {% else %}
+            <button type="button" class="telegram-login-button" disabled>
+              Telegram Login недоступен
+            </button>
+          {% endif %}
+        </div>
+      {% endif %}
     </section>
 
     {% if categories_error %}


### PR DESCRIPTION
## Summary
- add a Telegram authentication module that validates login widget payloads, stores users in Supabase, and exposes `/login` and `/me` endpoints
- include the new router in the FastAPI app while loading the current user from cookies for every rendered view
- update the homepage templates to show a Telegram login button or personalized greeting and add client-side logic to call the login endpoint

## Testing
- python -m compileall webapp

------
https://chatgpt.com/codex/tasks/task_e_68deb0581c9c832da6e8a1585fe05324