### PR TITLE
Add Bootstrap templates for quiz web app

### DIFF
--- a/webapp/templates/base.html
+++ b/webapp/templates/base.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}Командная Викторина{% endblock %}</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body class="bg-light">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+      <div class="container">
+        <a class="navbar-brand" href="/">Викторина</a>
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarNav"
+          aria-controls="navbarNav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item">
+              <a class="nav-link" href="/">Главная</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/team">Команда</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/quiz">Игра</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <main class="container py-5">
+      {% block content %}{% endblock %}
+    </main>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+      crossorigin="anonymous"
+    ></script>
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,14 +1,99 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>FastAPI Template</title>
-    <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}" />
-  </head>
-  <body>
-    <main>
-      <h1>FastAPI web application template</h1>
-      <p>If you can see this page, the project scaffold was set up correctly.</p>
-    </main>
-  </body>
-</html>
+{% extends "base.html" %}
+
+{% block title %}Главная · Командная Викторина{% endblock %}
+
+{% block content %}
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <div class="text-center mb-5">
+        <h1 class="display-5 fw-bold">Добро пожаловать в командную Викторину!</h1>
+        <p class="lead text-muted">
+          Проверьте приложение прямо в браузере: создайте свою команду или присоединитесь к существующей, а затем перейдите к экрану игры.
+        </p>
+      </div>
+
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h2 class="h4 mb-3">Создать команду</h2>
+          <form id="create-team-form" action="/team/create" method="post" novalidate>
+            <div class="mb-3">
+              <label for="team-name" class="form-label">Название команды</label>
+              <input type="text" class="form-control" id="team-name" name="team_name" placeholder="Например, Мозговой штурм" required />
+            </div>
+            <div class="mb-3">
+              <label for="create-user" class="form-label">ID пользователя</label>
+              <input type="number" class="form-control" id="create-user" name="user_id" placeholder="Введите ID" required />
+            </div>
+            <button type="submit" class="btn btn-success">Создать команду</button>
+          </form>
+          <div class="mt-3">
+            <h3 class="h6 text-muted">Ответ сервера</h3>
+            <pre class="bg-dark text-white p-3 rounded" id="create-team-response">Ожидание запроса…</pre>
+          </div>
+        </div>
+      </div>
+
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h2 class="h4 mb-3">Присоединиться к команде</h2>
+          <form id="join-team-form" action="/team/join" method="post" novalidate>
+            <div class="mb-3">
+              <label for="join-user" class="form-label">ID пользователя</label>
+              <input type="number" class="form-control" id="join-user" name="user_id" placeholder="Введите ID" required />
+            </div>
+            <div class="mb-3">
+              <label for="join-code" class="form-label">Код команды</label>
+              <input type="text" class="form-control" id="join-code" name="code" placeholder="Введите код" required />
+            </div>
+            <button type="submit" class="btn btn-primary">Присоединиться</button>
+          </form>
+          <div class="mt-3">
+            <h3 class="h6 text-muted">Ответ сервера</h3>
+            <pre class="bg-dark text-white p-3 rounded" id="join-team-response">Ожидание запроса…</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    const handleFormSubmit = (formId, responseId) => {
+      const form = document.getElementById(formId);
+      const responseContainer = document.getElementById(responseId);
+
+      if (!form || !responseContainer) return;
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        responseContainer.textContent = "Отправка запроса…";
+
+        const formData = new FormData(form);
+        const payload = {};
+        formData.forEach((value, key) => {
+          payload[key] = value;
+        });
+
+        try {
+          const fetchResponse = await fetch(form.action, {
+            method: form.method.toUpperCase(),
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          });
+
+          const data = await fetchResponse.json();
+          responseContainer.textContent = JSON.stringify(data, null, 2);
+        } catch (error) {
+          responseContainer.textContent = `Ошибка: ${error}`;
+        }
+      });
+    };
+
+    handleFormSubmit("create-team-form", "create-team-response");
+    handleFormSubmit("join-team-form", "join-team-response");
+  </script>
+{% endblock %}

--- a/webapp/templates/quiz.html
+++ b/webapp/templates/quiz.html
@@ -1,0 +1,147 @@
+{% extends "base.html" %}
+
+{% block title %}Игра · Командная Викторина{% endblock %}
+
+{% block content %}
+  {% set question = question or {} %}
+  {% set options = question.options or answers or [] %}
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h1 class="h3 mb-3">Текущий вопрос</h1>
+          {% if question.text %}
+            <p class="fs-5">{{ question.text }}</p>
+            <div class="list-group" id="answer-options">
+              {% for option in options %}
+                <button
+                  type="button"
+                  class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                  data-answer-id="{{ option.id or loop.index0 }}"
+                >
+                  <span>{{ option.text or option.title }}</span>
+                  <span class="badge text-bg-secondary">Выбрать</span>
+                </button>
+              {% endfor %}
+            </div>
+          {% else %}
+            <p class="text-muted mb-0">Вопросы не загружены. Используйте API, чтобы начать игру.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h2 class="h5 mb-3">Ответ API</h2>
+          <pre class="bg-dark text-white p-3 rounded" id="answer-response">Ожидание запроса…</pre>
+          <div class="mt-3" id="explanation-wrapper" hidden>
+            <h3 class="h6 text-muted">Объяснение</h3>
+            <p id="answer-explanation" class="mb-0"></p>
+          </div>
+        </div>
+      </div>
+
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h2 class="h5 mb-3">Следующий шаг</h2>
+          <form id="next-question-form" action="/game/next" method="post">
+            <input type="hidden" name="game_id" value="{{ game_id }}" />
+            <button type="submit" class="btn btn-outline-primary" id="next-question-button" disabled>
+              Следующий вопрос
+            </button>
+          </form>
+          <div class="mt-3">
+            <h3 class="h6 text-muted">Ответ сервера</h3>
+            <pre class="bg-dark text-white p-3 rounded" id="next-question-response">Ожидание запроса…</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script>
+    const answerList = document.getElementById("answer-options");
+    const answerResponse = document.getElementById("answer-response");
+    const explanationWrapper = document.getElementById("explanation-wrapper");
+    const explanationText = document.getElementById("answer-explanation");
+    const nextQuestionButton = document.getElementById("next-question-button");
+
+    const questionPayload = {{ {"question_id": question.id if question and (question.id is not none) else None}|tojson }};
+
+    if (answerList) {
+      answerList.addEventListener("click", async (event) => {
+        const target = event.target.closest("[data-answer-id]");
+        if (!target) return;
+
+        const answerId = target.getAttribute("data-answer-id");
+        answerResponse.textContent = "Отправка ответа…";
+        explanationWrapper.hidden = true;
+        explanationText.textContent = "";
+
+        try {
+          const fetchResponse = await fetch("/game/answer", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              ...questionPayload,
+              answer_id: answerId,
+            }),
+          });
+
+          const data = await fetchResponse.json();
+          answerResponse.textContent = JSON.stringify(data, null, 2);
+
+          if (data && data.explanation) {
+            explanationWrapper.hidden = false;
+            explanationText.textContent = data.explanation;
+          }
+
+          if (nextQuestionButton) {
+            nextQuestionButton.disabled = false;
+          }
+        } catch (error) {
+          answerResponse.textContent = `Ошибка: ${error}`;
+        }
+      });
+    }
+
+    const nextQuestionForm = document.getElementById("next-question-form");
+    const nextQuestionResponse = document.getElementById("next-question-response");
+
+    if (nextQuestionForm && nextQuestionResponse) {
+      nextQuestionForm.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        nextQuestionResponse.textContent = "Запрос отправляется…";
+
+        const formData = new FormData(nextQuestionForm);
+        const payload = {};
+        formData.forEach((value, key) => {
+          if (value) {
+            payload[key] = value;
+          }
+        });
+
+        try {
+          const fetchResponse = await fetch(nextQuestionForm.action, {
+            method: nextQuestionForm.method.toUpperCase(),
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+          });
+
+          const data = await fetchResponse.json();
+          nextQuestionResponse.textContent = JSON.stringify(data, null, 2);
+          nextQuestionButton.disabled = true;
+        } catch (error) {
+          nextQuestionResponse.textContent = `Ошибка: ${error}`;
+        }
+      });
+    }
+  </script>
+{% endblock %}

--- a/webapp/templates/team.html
+++ b/webapp/templates/team.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+
+{% block title %}Команда · Командная Викторина{% endblock %}
+
+{% block content %}
+  {% set team = team or {} %}
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h1 class="h3 mb-4">Информация о команде</h1>
+          <dl class="row">
+            <dt class="col-sm-4">Название</dt>
+            <dd class="col-sm-8">{{ team.name or "—" }}</dd>
+
+            <dt class="col-sm-4">Код приглашения</dt>
+            <dd class="col-sm-8">
+              {% if team.code %}
+                <span class="badge text-bg-primary fs-6">{{ team.code }}</span>
+              {% else %}
+                —
+              {% endif %}
+            </dd>
+
+            <dt class="col-sm-4">Участники</dt>
+            <dd class="col-sm-8">
+              {% if team.members %}
+                <ul class="list-group list-group-flush">
+                  {% for member in team.members %}
+                    <li class="list-group-item px-0">
+                      <span class="fw-semibold">{{ member.name or member.username or "Без имени" }}</span>
+                      {% if member.is_captain %}
+                        <span class="badge text-bg-warning ms-2">Капитан</span>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p class="text-muted mb-0">Пока нет участников.</p>
+              {% endif %}
+            </dd>
+          </dl>
+        </div>
+      </div>
+
+      {% if user_is_captain %}
+        <div class="card shadow-sm mb-4">
+          <div class="card-body">
+            <h2 class="h4 mb-3">Управление игрой</h2>
+            <form id="start-game-form" action="/team/start" method="post">
+              <div class="mb-3">
+                <label for="start-user" class="form-label">ID капитана</label>
+                <input type="number" class="form-control" id="start-user" name="user_id" value="{{ captain_id }}" placeholder="Введите ID" required />
+              </div>
+              <input type="hidden" name="team_id" value="{{ team.id }}" />
+              <button type="submit" class="btn btn-danger">Начать игру</button>
+            </form>
+            <div class="mt-3">
+              <h3 class="h6 text-muted">Ответ сервера</h3>
+              <pre class="bg-dark text-white p-3 rounded" id="start-game-response">Ожидание запроса…</pre>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+
+      {% if last_response %}
+        <div class="alert alert-info" role="alert">
+          <h2 class="h6 mb-2">Последний ответ API</h2>
+          <pre class="mb-0">{{ last_response | tojson(indent=2) }}</pre>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if user_is_captain %}
+    <script>
+      const startGameForm = document.getElementById("start-game-form");
+      const responseContainer = document.getElementById("start-game-response");
+
+      if (startGameForm && responseContainer) {
+        startGameForm.addEventListener("submit", async (event) => {
+          event.preventDefault();
+          responseContainer.textContent = "Отправка запроса…";
+
+          const formData = new FormData(startGameForm);
+          const payload = {};
+          formData.forEach((value, key) => {
+            payload[key] = value;
+          });
+
+          try {
+            const fetchResponse = await fetch(startGameForm.action, {
+              method: startGameForm.method.toUpperCase(),
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(payload),
+            });
+
+            const data = await fetchResponse.json();
+            responseContainer.textContent = JSON.stringify(data, null, 2);
+          } catch (error) {
+            responseContainer.textContent = `Ошибка: ${error}`;
+          }
+        });
+      }
+    </script>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a shared Bootstrap layout with navigation for the quiz mini app web UI
- build interactive index, team, and quiz pages that submit to the existing API and render JSON responses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa3fed5c8832d838556fae1a396f5