### PR TITLE
Render HTML templates for team flow

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -3,6 +3,13 @@
 {% block title %}Главная · Командная Викторина{% endblock %}
 
 {% block content %}
+  {% if login_success and user %}
+    <div class="alert alert-success text-start" role="alert">
+      <h2 class="h5 mb-2">Вход выполнен</h2>
+      <p class="mb-1">ID пользователя: <strong>{{ user.id }}</strong></p>
+      <p class="mb-0">Логин: {{ user.username or "—" }}</p>
+    </div>
+  {% endif %}
   <div class="text-center mt-5">
     <h1 class="display-5 fw-bold mb-4">Добро пожаловать в Командную Викторину 🎉</h1>
 


### PR DESCRIPTION
## Summary
- add shared helpers to parse JSON/form payloads and build team context data
- update login, team creation, team joining, and team start endpoints to render HTML templates when serving browser requests while keeping JSON responses for API clients
- surface a login success alert on the index page to show authenticated user details

## Testing
- python -m compileall webapp/main.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe7b3bfb4832d848a292a6af2305e