### PR TITLE
Add scoreboard summary to quiz completion screen

### DIFF
--- a/webapp/templates/game.html
+++ b/webapp/templates/game.html
@@ -64,9 +64,57 @@
         Нет вопросов для этой викторины. Попросите организатора добавить их в Supabase.
       </div>
     {% else %}
+      <div class="card shadow-sm mb-4">
+        <div class="card-body">
+          <h3 class="h4">Викторина завершена!</h3>
+          <p class="text-muted mb-4">Вы ответили на все вопросы. Спасибо за игру!</p>
+
+          {% if winning_team %}
+            <div class="mb-4">
+              <div class="fs-4 mb-1">🏆 {{ winning_team.team_name }}</div>
+              <div class="text-secondary">💯 {{ winning_team.score }} очков</div>
+            </div>
+          {% else %}
+            <p class="mb-4">Результаты команд появятся, как только организатор их опубликует.</p>
+          {% endif %}
+
+          {% if team_scoreboard %}
+            <div class="table-responsive">
+              <table class="table table-sm align-middle mb-0">
+                <thead class="table-light">
+                  <tr>
+                    <th scope="col" class="text-center">Место</th>
+                    <th scope="col">Команда</th>
+                    <th scope="col" class="text-end">Очки</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for entry in team_scoreboard %}
+                    {% set rank = loop.index %}
+                    {% if rank == 1 %}
+                      {% set medal = "🥇" %}
+                    {% elif rank == 2 %}
+                      {% set medal = "🥈" %}
+                    {% elif rank == 3 %}
+                      {% set medal = "🥉" %}
+                    {% else %}
+                      {% set medal = "" %}
+                    {% endif %}
+                    <tr>
+                      <td class="text-center">{{ medal }} {{ rank }}</td>
+                      <td>{{ entry.team_name }}</td>
+                      <td class="text-end fw-semibold">{{ entry.score }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+
       <div class="alert alert-info" role="alert">
-        Викторина завершена! Вы ответили на все вопросы. Можно вернуться на
-        <a href="/team" class="alert-link">страницу команды</a>
+        Можно вернуться на <a href="/team" class="alert-link">страницу команды</a>
         или на <a href="/" class="alert-link">главную</a>.
       </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- add a Supabase-backed helper to collect team scores for the finished match
- display the winning team and a mini leaderboard on the quiz completion screen

## Testing
- python -m compileall webapp

------
https://chatgpt.com/codex/tasks/task_e_68e133af5078832d9eab5b17fadd6bdb