### PR TITLE
Add quiz selection for team captains

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -96,6 +96,12 @@ class DeleteTeamRequest(BaseModel):
     team_id: str
 
 
+class SelectQuizRequest(BaseModel):
+    user_id: int
+    team_id: str
+    quiz_id: int
+
+
 # ------------------- ВСПОМОГАТЕЛЬНЫЕ -------------------
 
 

--- a/webapp/services/supabase_client.py
+++ b/webapp/services/supabase_client.py
@@ -90,6 +90,21 @@ async def _fetch_single_record(table: str, filters: Dict[str, str], select: str 
     return data[0] if data else None
 
 
+async def _fetch_quiz_options(select: str = "id,title") -> List[Dict[str, Any]]:
+    """Возвращает список викторин с указанными полями (по умолчанию id и title)."""
+
+    params = {"select": select, "order": "title.asc"}
+    quizzes = await _supabase_request("GET", "quizzes", params=params) or []
+    normalized: List[Dict[str, Any]] = []
+    for quiz in quizzes:
+        if not isinstance(quiz, dict):
+            continue
+        if quiz.get("id") in (None, ""):
+            continue
+        normalized.append(quiz)
+    return normalized
+
+
 async def _fetch_active_quiz() -> Dict[str, Any]:
     quiz = await _fetch_single_record("quizzes", {"is_active": "eq.true"}, select="id,title,description")
     if not quiz:
@@ -108,4 +123,9 @@ async def _fetch_active_quiz() -> Dict[str, Any]:
     return quiz
 
 
-__all__ = ["_supabase_request", "_fetch_single_record", "_fetch_active_quiz"]
+__all__ = [
+    "_supabase_request",
+    "_fetch_single_record",
+    "_fetch_active_quiz",
+    "_fetch_quiz_options",
+]

--- a/webapp/templates/team.html
+++ b/webapp/templates/team.html
@@ -85,6 +85,65 @@
         <div class="card shadow-sm mb-4">
           <div class="card-body">
             <h2 class="h4 mb-3">Управление игрой</h2>
+            <div class="mb-4">
+              <h3 class="h6 text-muted">Викторина</h3>
+              {% if selected_quiz %}
+                <p class="mb-2">
+                  Выбрана викторина <span class="fw-semibold">«{{ selected_quiz.title }}»</span>.
+                </p>
+              {% elif selected_quiz_id %}
+                <p class="mb-2">Выбрана викторина № {{ selected_quiz_id }}.</p>
+              {% else %}
+                <p class="mb-2 text-muted">Викторина пока не выбрана.</p>
+              {% endif %}
+
+              {% if quiz_error %}
+                <div class="alert alert-warning mb-3" role="alert">
+                  {{ quiz_error }}
+                </div>
+              {% endif %}
+
+              {% if user_is_captain %}
+                {% if available_quizzes %}
+                  <div class="list-group mb-0">
+                    {% for quiz in available_quizzes %}
+                      {% set quiz_id_str = quiz.id ~ '' %}
+                      {% set is_selected = selected_quiz_id_str and selected_quiz_id_str == quiz_id_str %}
+                      <form
+                        action="/team/select-quiz"
+                        method="post"
+                        class="list-group-item list-group-item-action"
+                      >
+                        <input type="hidden" name="team_id" value="{{ team.id }}" />
+                        <input
+                          type="hidden"
+                          name="user_id"
+                          value="{{ captain_id or (current_user.id if current_user else '') }}"
+                        />
+                        <input type="hidden" name="quiz_id" value="{{ quiz.id }}" />
+                        <div class="d-flex flex-column flex-md-row align-items-start align-items-md-center gap-2">
+                          <div class="flex-grow-1">
+                            <span class="fw-semibold">{{ quiz.title or ('Викторина № ' ~ quiz.id) }}</span>
+                            {% if is_selected %}
+                              <span class="badge text-bg-success ms-2">Выбрано</span>
+                            {% endif %}
+                          </div>
+                          <button
+                            type="submit"
+                            class="btn btn-outline-primary btn-sm ms-md-auto"
+                            {% if is_selected %}disabled{% endif %}
+                          >
+                            {% if is_selected %}Выбрано{% else %}Выбрать{% endif %}
+                          </button>
+                        </div>
+                      </form>
+                    {% endfor %}
+                  </div>
+                {% else %}
+                  <p class="text-muted mb-0">Нет доступных викторин для выбора.</p>
+                {% endif %}
+              {% endif %}
+            </div>
             {% if user_is_captain %}
               <form id="start-game-form" action="/team/start" method="post">
                 <input type="hidden" name="user_id" value="{{ captain_id }}" />


### PR DESCRIPTION
## Summary
- add a request model and endpoint so captains can persist their quiz choice and keep match caches in sync
- load quiz options from Supabase, reuse any existing selection for the whole match, and expose the data to the team view context
- extend the team page with a captain-only quiz picker that highlights the current selection

## Testing
- python -m compileall webapp

------
https://chatgpt.com/codex/tasks/task_e_68e27f788130832daab3226430a7fe48