### PR TITLE
Adjust redirect handling for finished matches

### DIFF
--- a/webapp/services/match_service.py
+++ b/webapp/services/match_service.py
@@ -9,6 +9,7 @@ from webapp.utils.cache import (
     MATCH_STATUS_CACHE,
     MATCH_TEAM_CACHE,
     MATCH_QUIZ_CACHE,
+    TEAM_PROGRESS_CACHE,
     TEAM_READY_CACHE,
 )
 
@@ -30,7 +31,20 @@ def _collect_match_team_statuses(teams: List[Dict[str, Any]]) -> Tuple[List[Dict
         else:
             ready = bool(cached_ready)
 
-        statuses.append({"id": team_id, "name": team_name, "ready": ready})
+        extra_fields: Dict[str, Any] = {}
+        for key in (
+            "status",
+            "team_status",
+            "team_completed",
+            "completed",
+            "finished",
+            "start_time",
+            "team_start_time",
+        ):
+            if key in team:
+                extra_fields[key] = team.get(key)
+
+        statuses.append({"id": team_id, "name": team_name, "ready": ready, **extra_fields})
 
         if not ready:
             all_ready = False
@@ -151,23 +165,160 @@ async def _build_match_status_response(
         if team_id:
             cached_team_ids.add(team_id)
 
-        response_teams.append(
-            {
-                "id": team_id,
-                "name": status.get("name") or team_id,
-                "ready": bool(status.get("ready")),
-                "is_yours": bool(your_team_id and team_id == your_team_id),
-            }
+        team_payload: Dict[str, Any] = {
+            "id": team_id,
+            "name": status.get("name") or team_id,
+            "ready": bool(status.get("ready")),
+            "is_yours": bool(your_team_id and team_id == your_team_id),
+        }
+
+        for extra_key in ("status", "team_status", "team_completed", "completed", "finished"):
+            if extra_key in status:
+                team_payload[extra_key] = status.get(extra_key)
+
+        response_teams.append(team_payload)
+
+    def _extract_first(source: Optional[Dict[str, Any]], keys: Tuple[str, ...]) -> Any:
+        if not source:
+            return None
+        for key in keys:
+            if key in source:
+                return source.get(key)
+        return None
+
+    def _coerce_bool(value: Any) -> Optional[bool]:
+        if isinstance(value, bool):
+            return value
+        if value in (None, ""):
+            return None
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if not normalized:
+                return None
+            if normalized in {"1", "true", "yes", "y", "on"}:
+                return True
+            if normalized in {"0", "false", "no", "n", "off"}:
+                return False
+        return None
+
+    def _normalize_status(value: Any) -> Optional[str]:
+        if value in (None, ""):
+            return None
+        if isinstance(value, str):
+            return value.strip().lower() or None
+        return str(value)
+
+    fallback_team_completed = _coerce_bool(
+        _extract_first(
+            fallback_team,
+            ("team_completed", "teamCompleted", "completed", "finished"),
         )
+    )
+    fallback_match_completed = _coerce_bool(
+        _extract_first(
+            fallback_team,
+            ("match_team_completed", "matchTeamCompleted"),
+        )
+    )
+    fallback_team_status = _normalize_status(
+        _extract_first(
+            fallback_team,
+            ("team_status", "teamStatus", "status"),
+        )
+    )
+    fallback_match_status = _normalize_status(
+        _extract_first(
+            fallback_team,
+            ("match_status", "matchStatus"),
+        )
+    )
+    fallback_results_url = _extract_first(
+        fallback_team,
+        ("results_url", "resultsUrl"),
+    )
+    fallback_redirect_url = _extract_first(
+        fallback_team,
+        ("redirect", "redirect_url", "redirectUrl"),
+    )
+
+    team_progress = None
+    if match_id and your_team_id:
+        match_progress = TEAM_PROGRESS_CACHE.get(match_id)
+        if isinstance(match_progress, dict):
+            team_progress = match_progress.get(your_team_id)
+
+    cached_team_completed = None
+    if isinstance(team_progress, dict):
+        cached_team_completed = _coerce_bool(team_progress.get("team_completed"))
+        if cached_team_completed is None and team_progress.get("team_completed") is not None:
+            cached_team_completed = bool(team_progress.get("team_completed"))
+
+    team_completed = (
+        fallback_team_completed
+        if fallback_team_completed is not None
+        else cached_team_completed
+    )
+
+    team_started = False
+    if isinstance(team_progress, dict) and team_progress.get("team_start_time"):
+        team_started = True
+    elif fallback_team and fallback_team.get("start_time"):
+        team_started = True
+
+    match_status_value = fallback_match_status
+    if not match_status_value:
+        if team_completed:
+            match_status_value = "finished"
+        elif team_started:
+            match_status_value = "started"
+        elif all_ready:
+            match_status_value = "started"
+        else:
+            match_status_value = "waiting"
+
+    team_status_value = fallback_team_status
+    if not team_status_value:
+        if team_completed:
+            team_status_value = "finished"
+        elif team_started:
+            team_status_value = "started"
+        elif fallback_team and fallback_team.get("ready"):
+            team_status_value = "ready"
+        else:
+            team_status_value = "waiting"
 
     response: dict[str, Any] = {
-        "status": "ready" if all_ready else "waiting",
+        "status": match_status_value,
         "teams": response_teams,
         "match_id": match_id,
     }
 
-    if all_ready:
-        response["redirect"] = f"/game/{match_id}"
+    if team_status_value:
+        response["team_status"] = team_status_value
+
+    if team_completed is not None:
+        response["team_completed"] = bool(team_completed)
+
+    if fallback_match_completed is not None:
+        response["match_team_completed"] = bool(fallback_match_completed)
+
+    if fallback_results_url:
+        response["results_url"] = fallback_results_url
+
+    redirect_candidate = fallback_redirect_url
+    if not redirect_candidate and (team_started or all_ready):
+        redirect_candidate = f"/game/{match_id}"
+
+    should_redirect = (
+        redirect_candidate
+        and match_status_value == "started"
+        and not bool(team_completed)
+        and not bool(fallback_match_completed)
+    )
+
+    response["redirect"] = redirect_candidate if should_redirect else None
 
     MATCH_STATUS_CACHE[match_id] = response
     return response


### PR DESCRIPTION
## Summary
- extend match status aggregation with additional fields from team data and cached progress
- ensure match status endpoint only emits redirect links when the match is in progress and the team is not finished
- surface derived team and match completion metadata in the status response

## Testing
- python -m compileall webapp/services/match_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e3bdc01a7c832d86a7976a0c7428d5