### PR TITLE
Fix match status highlights when match finishes

### DIFF
--- a/webapp/templates/team.html
+++ b/webapp/templates/team.html
@@ -592,6 +592,12 @@
           markMatchFinished();
         }
 
+        if (status === "finished") {
+          applyStatusHighlight("finished");
+          renderFinishedStatus(data);
+          return;
+        }
+
         const dataTeamStatus = normalizeStatus(data.team_status || data.teamStatus);
         const dataTeamCompleted = parseBoolean(
           data.team_completed !== undefined ? data.team_completed : data.teamCompleted
@@ -628,6 +634,7 @@
         }
         if (!highlightStatus && teamFinished) {
           highlightStatus = "waiting";
+          applyStatusHighlight("waiting");
         }
         if (highlightStatus) {
           applyStatusHighlight(highlightStatus);


### PR DESCRIPTION
## Summary
- ensure match status updates render the finished message immediately when the server reports the match is finished
- highlight the waiting step as soon as the local team finishes while others are still playing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d6f808c0832db0e32dcd9fdf1eaf