### PR TITLE
Fix team status polling fallback when initial JSON missing

### DIFF
--- a/webapp/templates/team.html
+++ b/webapp/templates/team.html
@@ -673,23 +673,39 @@
           return;
         }
 
-        const pollResponse = await fetch(`/match/status/${encodeURIComponent(normalizedId)}`);
+        const pollResponse = await fetch(`/match/status/${encodeURIComponent(normalizedId)}`, {
+          credentials: "same-origin",
+        });
         const pollData = await handleJsonResponse(pollResponse);
         updateMatchStatus(pollData);
       };
 
-      if (statusDataset && statusDataset.initialStatus) {
-        try {
-          const initialStatus = JSON.parse(statusDataset.initialStatus);
-          updateMatchStatus(initialStatus);
-        } catch (error) {
-          console.warn("Failed to parse initial match status", error);
+      const requestInitialStatus = () => {
+        if (!currentMatchId) {
+          return Promise.resolve();
         }
-        delete statusMessage.dataset.initialStatus;
-      } else if (currentMatchId) {
-        fetchMatchStatus(currentMatchId).catch((error) => {
+        return fetchMatchStatus(currentMatchId).catch((error) => {
           console.error("Failed to fetch initial match status", error);
+          renderError(error.message || String(error));
         });
+      };
+
+      if (statusDataset && "initialStatus" in statusDataset) {
+        const rawInitialStatus = statusDataset.initialStatus;
+        delete statusMessage.dataset.initialStatus;
+        if (rawInitialStatus && rawInitialStatus.trim().length > 0) {
+          try {
+            const initialStatus = JSON.parse(rawInitialStatus);
+            updateMatchStatus(initialStatus);
+          } catch (error) {
+            console.warn("Failed to parse initial match status", error);
+            requestInitialStatus();
+          }
+        } else {
+          requestInitialStatus();
+        }
+      } else if (currentMatchId) {
+        requestInitialStatus();
       }
 
       const startGameForm = document.getElementById("start-game-form");


### PR DESCRIPTION
## Summary
- add robust initial status loading on the team page by retrying with a fetch when parsing fails or data is missing
- ensure match status polling requests include credentials so authenticated APIs respond correctly
- surface an error message if the initial status request fails so the UI does not remain stuck on the placeholder

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e40a64a4b4832d8b0d60ee1791e8a0