### PR TITLE
Enhance team completion messaging

### DIFF
--- a/webapp/templates/team.html
+++ b/webapp/templates/team.html
@@ -22,9 +22,10 @@
     <div class="col-lg-9 col-xl-8">
       <div id="match-summary-alert">
         {% if match_finished %}
+          {% set match_message = match_info.message or '✅ Игра завершена.' %}
           <div class="alert alert-success">
             <p class="mb-0">
-              ✅ Игра завершена.
+              {{ match_message }}
               {% if match_info.results_url %}
                 <a class="alert-link" href="{{ match_info.results_url }}">Посмотреть результаты</a>.
               {% else %}
@@ -33,8 +34,9 @@
             </p>
           </div>
         {% elif team_finished %}
+          {% set waiting_message = match_info.message or '🏁 Ваша команда завершила игру. Ожидаем вторую команду…' %}
           <div class="alert alert-success">
-            <p class="mb-0">🏁 Ваша команда завершила игру. Ожидаем остальные команды...</p>
+            <p class="mb-0">{{ waiting_message }}</p>
           </div>
         {% endif %}
       </div>
@@ -210,6 +212,9 @@
       const statusDataset = statusMessage && statusMessage.dataset ? statusMessage.dataset : null;
       const statusSteps = document.querySelectorAll("[data-status-step]");
 
+      const TEAM_FINISHED_DEFAULT_MESSAGE = "🏁 Ваша команда завершила игру. Ожидаем вторую команду…";
+      const MATCH_FINISHED_FALLBACK_MESSAGE = "✅ Игра завершена. Результаты готовы.";
+
       const normalizeId = (value) => {
         if (typeof value !== "string") return null;
         const trimmed = value.trim();
@@ -299,24 +304,34 @@
         });
       };
 
+      const normalizeMessage = (value, fallback) => {
+        if (typeof value === "string") {
+          const trimmed = value.trim();
+          if (trimmed) return trimmed;
+        }
+        return fallback;
+      };
+
       const renderSummary = (html) => {
         if (!summaryContainer) return;
         summaryContainer.innerHTML = html || "";
       };
 
-      const renderTeamCompletedSummary = () => {
+      const renderTeamCompletedSummary = (message) => {
+        const text = normalizeMessage(message, TEAM_FINISHED_DEFAULT_MESSAGE);
         renderSummary(
-          '<div class="alert alert-success"><p class="mb-0">🏁 Ваша команда завершила игру. Ожидаем остальные команды...</p></div>'
+          `<div class="alert alert-success"><p class="mb-0">${escapeHtml(text)}</p></div>`
         );
       };
 
-      const renderMatchFinishedSummary = (resultsUrl) => {
-        const linkHtml =
+      const renderMatchFinishedSummary = (message, resultsUrl) => {
+        const text = normalizeMessage(message, MATCH_FINISHED_FALLBACK_MESSAGE);
+        const suffix =
           typeof resultsUrl === "string" && resultsUrl
-            ? `<a class="alert-link" href="${escapeHtml(resultsUrl)}">Посмотреть результаты</a>.`
-            : `${escapeHtml("Посмотреть результаты.")}`;
+            ? ` <a class="alert-link" href="${escapeHtml(resultsUrl)}">Посмотреть результаты</a>.`
+            : ` ${escapeHtml("Посмотреть результаты.")}`;
         renderSummary(
-          `<div class="alert alert-success"><p class="mb-0">✅ ${escapeHtml("Игра завершена.")} ${linkHtml}</p></div>`
+          `<div class="alert alert-success"><p class="mb-0">${escapeHtml(text)}${suffix}</p></div>`
         );
       };
 
@@ -381,11 +396,11 @@
         return url.toString();
       };
 
-      const renderTeamCompletedStatus = () => {
+      const renderTeamCompletedStatus = (message) => {
         if (!statusMessage) return;
-        statusMessage.innerHTML =
-          '<p class="mb-0 text-success">🏁 Ваша команда завершила игру. Ожидаем остальные команды...</p>';
-        renderTeamCompletedSummary();
+        const text = normalizeMessage(message, TEAM_FINISHED_DEFAULT_MESSAGE);
+        statusMessage.innerHTML = `<p class="mb-0 text-success">${escapeHtml(text)}</p>`;
+        renderTeamCompletedSummary(text);
       };
 
       const shouldRedirectToGame = (data) => {
@@ -500,13 +515,12 @@
       const renderFinishedStatus = (data) => {
         if (!statusMessage) return;
         const resultsUrl = typeof data?.results_url === "string" && data.results_url ? data.results_url : null;
-        const baseText = escapeHtml("✅ Игра завершена.");
-        if (resultsUrl) {
-          statusMessage.innerHTML = `<p class="mb-0 text-success">${baseText} <a class="link-success fw-semibold" href="${escapeHtml(resultsUrl)}">Посмотреть результаты</a>.</p>`;
-        } else {
-          statusMessage.innerHTML = `<p class="mb-0 text-success">${baseText} ${escapeHtml("Посмотреть результаты.")}</p>`;
-        }
-        renderMatchFinishedSummary(resultsUrl);
+        const messageText = normalizeMessage(data?.message, MATCH_FINISHED_FALLBACK_MESSAGE);
+        const suffix = resultsUrl
+          ? ` <a class="link-success fw-semibold" href="${escapeHtml(resultsUrl)}">Посмотреть результаты</a>.`
+          : ` ${escapeHtml("Посмотреть результаты.")}`;
+        statusMessage.innerHTML = `<p class="mb-0 text-success">${escapeHtml(messageText)}${suffix}</p>`;
+        renderMatchFinishedSummary(messageText, resultsUrl);
         stopPolling();
       };
 
@@ -571,7 +585,7 @@
 
         // 4) Рендер в зависимости от состояния
         if (teamFinished && !matchFinished) {
-          renderTeamCompletedStatus();
+          renderTeamCompletedStatus(data?.message);
           startPolling();
           return;
         }


### PR DESCRIPTION
## Summary
- add a match result summarizer to expose the winner message and waiting text for team views
- update the team router to attach waiting/result messages and summaries to the rendered context
- refresh the team template logic so the UI and polling show the new messages when teams finish

## Testing
- python -m compileall webapp

------
https://chatgpt.com/codex/tasks/task_e_68e42a935f60832daa527e1a61e3ef46